### PR TITLE
fix incorrect make target for app

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,8 @@ MKDIRP = mkdir -p
 $(ODIR)/%.o: $(SDIR)/%.c $(HEADERS)
 	$(CC) -c -o $@ $< $(CFLAGS)
 
-app: $(OBJ) app.c
-	$(CC) -o $(OUTDIR)/$@ $^ $(CFLAGS) $(LIBS)
+$(OUTDIR)/app: $(OBJ) app.c
+	$(CC) -o $@ $^ $(CFLAGS) $(LIBS)
 
 .PHONY: clean
 


### PR DESCRIPTION
Currently, the target for `app` does not include the output directory
causing this to always be rebuilt. This commit adds the output directory
to avoid this.