### PR TITLE
add missing include in uvwasi.c

### DIFF
--- a/src/uvwasi.c
+++ b/src/uvwasi.c
@@ -1,4 +1,5 @@
 #include <stdlib.h>
+#include <string.h>
 
 #ifndef _WIN32
 # include <sched.h>


### PR DESCRIPTION
`uvwasi.c` uses functions from `string.h` without directly or indirectly including the header file.