### PR TITLE
remove stdio.h include from app

### DIFF
--- a/app.c
+++ b/app.c
@@ -1,5 +1,4 @@
 #include <assert.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include "uv.h"


### PR DESCRIPTION
This commit removes `stdio.h` as I can't find any usage of any library
variables/macros/functions from stdio.h (previously printf was used
though).