### PR TITLE
support remapping host fds of sandbox

### DIFF
--- a/include/uvwasi.h
+++ b/include/uvwasi.h
@@ -49,9 +49,15 @@ typedef struct uvwasi_options_s {
 } uvwasi_options_t;
 
 
+// Embedder API.
 uvwasi_errno_t uvwasi_init(uvwasi_t* uvwasi, uvwasi_options_t* options);
 void uvwasi_destroy(uvwasi_t* uvwasi);
+uvwasi_errno_t uvwasi_embedder_remap_fd(uvwasi_t* uvwasi,
+                                        const uvwasi_fd_t fd,
+                                        uv_file new_host_fd);
 
+
+// WASI system call API.
 uvwasi_errno_t uvwasi_args_get(uvwasi_t* uvwasi, char** argv, char* argv_buf);
 uvwasi_errno_t uvwasi_args_sizes_get(uvwasi_t* uvwasi,
                                      size_t* argc,

--- a/src/uvwasi.c
+++ b/src/uvwasi.c
@@ -352,6 +352,24 @@ void uvwasi_destroy(uvwasi_t* uvwasi) {
 }
 
 
+uvwasi_errno_t uvwasi_embedder_remap_fd(uvwasi_t* uvwasi,
+                                        const uvwasi_fd_t fd,
+                                        uv_file new_host_fd) {
+  struct uvwasi_fd_wrap_t* wrap;
+  uvwasi_errno_t err;
+
+  if (uvwasi == NULL)
+    return UVWASI_EINVAL;
+
+  err = uvwasi_fd_table_get(&uvwasi->fds, fd, &wrap, 0, 0);
+  if (err != UVWASI_ESUCCESS)
+    return err;
+
+  wrap->fd = new_host_fd;
+  return UVWASI_ESUCCESS;
+}
+
+
 uvwasi_errno_t uvwasi_args_get(uvwasi_t* uvwasi, char** argv, char* argv_buf) {
   size_t i;
 


### PR DESCRIPTION
This commit adds a `uvwasi_embedder_remap_fd()` API which allows the embedder (for example, Node.js) to change out the underlying host file descriptor of a WASI file descriptor.

One use case for this is allowing the stdio streams of individual WASI instances to be changed. I tested with Node.js, and it seems to work as intended.

This is intended as a fix for https://github.com/cjihrig/uvwasi/issues/13. I decided not to add it as an option to `uvwasi_init()`.

cc: @danbev @tniessen @guybedford