### PR TITLE
add missing #include

### DIFF
--- a/src/fd_table.c
+++ b/src/fd_table.c
@@ -1,4 +1,5 @@
 #include <stdlib.h>
+#include <string.h>
 #include <sys/stat.h>
 #include "uv.h"
 #include "fd_table.h"


### PR DESCRIPTION
The file uses `strcpy()`.