### PR TITLE
fix a few compiler warnings

### DIFF
--- a/app.c
+++ b/app.c
@@ -100,7 +100,6 @@ int main(void) {
                        fs_flags,
                        &fd);
   assert(r == 0);
-  assert(fd >= 0);
 
   r = uvwasi_fd_sync(uvw, fd);
   assert(r == 0);


### PR DESCRIPTION
This commit fixes a few compiler warnings. It also adds some Windows `#ifdef` logic. The resulting Windows code does not work, but it didn't work before this either (the goal is to get it compiling).

Fixes: https://github.com/cjihrig/uvwasi/issues/26 (I hope)
Green CI: https://github.com/cjihrig/uvwasi/commit/5df92f87e3259a7c941a83fd0c4449e230127780/checks?check_suite_id=262439257 (apologies if I'm doing something wrong with the GitHub CI, this is my first exposure to it)
cc: @gengjiawen