### PR TITLE
Fix visual studio compiler compatibility

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,5 +24,6 @@ jobs:
       - name: Build and Test on windows
         if: matrix.os == 'windows-latest'
         run: |
+          "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
           cmake -G "CodeBlocks - NMake Makefiles" .
           cmake --build . --target check

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,7 +16,7 @@ jobs:
           node-version: 12.x
       - name: Environment Information
         run: npx envinfo
-      - name: build it
+      - name: Build and Test
         run: |
           cmake .
           cmake --build . --target check

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,12 +16,12 @@ jobs:
           node-version: 12.x
       - name: Environment Information
         run: npx envinfo
-      - name: Build and Test
+      - name: Build and Test on ubuntu and macOS
         if: matrix.os != 'windows-latest'
         run: |
           cmake .
           cmake --build . --target check
-      - name: Build and Test
+      - name: Build and Test on windows
         if: matrix.os == 'windows-latest'
         run: |
           cmake -G "CodeBlocks - NMake Makefiles" .

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,14 +16,6 @@ jobs:
           node-version: 12.x
       - name: Environment Information
         run: npx envinfo
-      - name: Build and Test on ubuntu and macOS
-        if: matrix.os != 'windows-latest'
-        run: |
+      - name: Build and Test
           cmake .
-          cmake --build . --target check
-      - name: Build and Test on windows
-        if: matrix.os == 'windows-latest'
-        run: |
-          "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-          cmake -G "CodeBlocks - NMake Makefiles" .
           cmake --build . --target check

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,10 +4,10 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ${{ matrix.operating-system }}
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        operating-system: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
       - uses: actions/checkout@v1
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,8 +17,12 @@ jobs:
       - name: Environment Information
         run: npx envinfo
       - name: Build and Test
+        if: matrix.os != 'windows-latest'
         run: |
           cmake .
           cmake --build . --target check
-        env:
-          CI: true
+      - name: Build and Test
+        if: matrix.os == 'windows-latest'
+        run: |
+          cmake -G "CodeBlocks - NMake Makefiles" .
+          cmake --build . --target check

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,5 +17,6 @@ jobs:
       - name: Environment Information
         run: npx envinfo
       - name: Build and Test
+        run: |
           cmake .
           cmake --build . --target check

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,8 @@
 cmake_minimum_required(VERSION 3.11)
 project (uvwasi LANGUAGES C)
 
-set(LIBUV_VERSION 1.32.0)
+# This can be a commit hash or tag
+set(LIBUV_VERSION v1.32.0)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/out)
 
@@ -20,7 +21,7 @@ include(FetchContent)
 FetchContent_Declare(
         libuv
         GIT_REPOSITORY https://github.com/libuv/libuv.git
-        GIT_TAG v${LIBUV_VERSION})
+        GIT_TAG ${LIBUV_VERSION})
 
 FetchContent_GetProperties(libuv)
 if(NOT libuv_POPULATED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,6 @@ foreach(file ${test_files})
 endforeach()
 
 add_custom_target(check
-    COMMAND ctest -R test-
+    COMMAND ctest -C Debug -R test-
     DEPENDS ${test_list}
 )

--- a/src/uvwasi.c
+++ b/src/uvwasi.c
@@ -10,7 +10,6 @@
 # define SLASH_STR "/"
 # define IS_SLASH(c) ((c) == '/')
 #else
-# include <processthreadsapi.h>
 # define SLASH '\\'
 # define SLASH_STR "\\"
 # define IS_SLASH(c) ((c) == '/' || (c) == '\\')

--- a/src/uvwasi.c
+++ b/src/uvwasi.c
@@ -1155,12 +1155,12 @@ uvwasi_errno_t uvwasi_fd_readdir(uvwasi_t* uvwasi,
       /* Write dirent to the buffer. */
       available = buf_len - *bufused;
       size_to_cp = sizeof(dirent) > available ? available : sizeof(dirent);
-      memcpy(buf + *bufused, &dirent, size_to_cp);
+      memcpy((char*)buf + *bufused, &dirent, size_to_cp);
       *bufused += size_to_cp;
       /* Write the entry name to the buffer. */
       available = buf_len - *bufused;
       size_to_cp = name_len > available ? available : name_len;
-      memcpy(buf + *bufused, &dirents[i].name, size_to_cp);
+      memcpy((char*)buf + *bufused, &dirents[i].name, size_to_cp);
       *bufused += size_to_cp;
     }
 


### PR DESCRIPTION
Fix #31.

But test not running due to 

https://github.com/gengjiawen/uvwasi/runs/258268519
```console
  Building Custom Rule D:/a/uvwasi/uvwasi/CMakeLists.txt
  test-proc-exit.c
  test-proc-exit.vcxproj -> D:\a\uvwasi\uvwasi\out\Debug\test-proc-exit.exe
  Test project D:/a/uvwasi/uvwasi
      Start 1: test-args-get
  Test not available without configuration.  (Missing "-C <config>"?)
  1/2 Test #1: test-args-get ....................***Not Run   0.00 sec
      Start 2: test-proc-exit
  Test not available without configuration.  (Missing "-C <config>"?)
  2/2 Test #2: test-proc-exit ...................***Not Run   0.00 sec
  
  0% tests passed, 2 tests failed out of 2
  
  Total Test time (real) =   0.07 sec
  
  The following tests FAILED:
  	  1 - test-args-get (Not Run)
  	  2 - test-proc-exit (Not Run)
  Errors while running CTest
```

Update:
Check actually works on my windows 10, not sure which part go wrong.
```console
C:\Users\gengjiawen\AppData\Local\JetBrains\Toolbox\apps\CLion\ch-0\192.6817.32\bin\cmake\win\bin\cmake.exe --build D:\Developer\code\uvwasi\cmake-build-debug --target check --
[ 75%] Built target uv_a
[ 91%] Built target uvwasi_a
[100%] Built target test-args-get
[100%] Built target test-proc-exit
Test project D:/Developer/code/uvwasi/cmake-build-debug
    Start 1: test-args-get
1/2 Test #1: test-args-get ....................   Passed    0.12 sec
    Start 2: test-proc-exit
2/2 Test #2: test-proc-exit ...................   Passed    0.11 sec

100% tests passed, 0 tests failed out of 2

Total Test time (real) =   0.24 sec
[100%] Built target check
```
