### PR TITLE
add cmake configuration summary

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,3 +71,14 @@ add_custom_target(check
     COMMAND ctest -R test-
     DEPENDS ${test_list}
 )
+
+message(STATUS "summary of build options:
+
+    Install prefix:  ${CMAKE_INSTALL_PREFIX}
+    Target system:   ${CMAKE_SYSTEM_NAME}
+    Compiler:
+      C compiler:    ${CMAKE_C_COMPILER}
+      CFLAGS:        ${CMAKE_C_FLAGS_${_build_type}} ${CMAKE_C_FLAGS}
+    Libuv version:   ${LIBUV_VERSION}
+    Libuv lib:       ${libuv_BINARY_DIR}
+")


### PR DESCRIPTION
This commit adds the message command to CMakeLists.txt to output a
summary of some useful information. The following will be displayed when
with this addition:
```console
$ cd build && cmake ..
-- summary of build options:

    Install prefix:  /usr/local
    Target system:   Darwin
    Compiler:
      C compiler:    /work/ccache/ccache
      CFLAGS:         -g -I/work/nodejs/libuv-build/include
    Libuv version:   1.32.0
    Libuv lib:       /work/wasm/uvwasi/build/_deps/libuv-build

-- Configuring done
-- Generating done
-- Build files have been written to: //work/wasm/uvwasi/build
```