### PR TITLE
add custom allocator option

### DIFF
--- a/app.c
+++ b/app.c
@@ -40,6 +40,7 @@ int main(void) {
   init_options.preopens = calloc(1, sizeof(uvwasi_preopen_t));
   init_options.preopens[0].mapped_path = "/var";
   init_options.preopens[0].real_path = ".";
+  init_options.allocator = NULL;
 
   r = uvwasi_init(uvw, &init_options);
   assert(r == 0);

--- a/include/fd_table.h
+++ b/include/fd_table.h
@@ -16,6 +16,7 @@
 # define PATH_MAX_BYTES (PATH_MAX)
 #endif
 
+struct uvwasi_s;
 
 struct uvwasi_fd_wrap_t {
   uvwasi_fd_t id;
@@ -37,14 +38,18 @@ struct uvwasi_fd_table_t {
   uv_rwlock_t rwlock;
 };
 
-uvwasi_errno_t uvwasi_fd_table_init(struct uvwasi_fd_table_t* table,
+uvwasi_errno_t uvwasi_fd_table_init(struct uvwasi_s* uvwasi,
+                                    struct uvwasi_fd_table_t* table,
                                     uint32_t init_size);
-void uvwasi_fd_table_free(struct uvwasi_fd_table_t* table);
-uvwasi_errno_t uvwasi_fd_table_insert_preopen(struct uvwasi_fd_table_t* table,
+void uvwasi_fd_table_free(struct uvwasi_s* uvwasi,
+                          struct uvwasi_fd_table_t* table);
+uvwasi_errno_t uvwasi_fd_table_insert_preopen(struct uvwasi_s* uvwasi,
+                                              struct uvwasi_fd_table_t* table,
                                               const uv_file fd,
                                               const char* path,
                                               const char* real_path);
-uvwasi_errno_t uvwasi_fd_table_insert_fd(struct uvwasi_fd_table_t* table,
+uvwasi_errno_t uvwasi_fd_table_insert_fd(struct uvwasi_s* uvwasi,
+                                         struct uvwasi_fd_table_t* table,
                                          const uv_file fd,
                                          const int flags,
                                          const char* path,

--- a/include/uvwasi.h
+++ b/include/uvwasi.h
@@ -22,6 +22,18 @@ extern "C" {
                               UVWASI_STRINGIFY(UVWASI_VERSION_PATCH)
 #define UVWASI_VERSION_WASI "snapshot_0"
 
+typedef void* (*uvwasi_malloc)(size_t size, void* mem_user_data);
+typedef void (*uvwasi_free)(void* ptr, void* mem_user_data);
+typedef void* (*uvwasi_calloc)(size_t nmemb, size_t size, void* mem_user_data);
+typedef void* (*uvwasi_realloc)(void* ptr, size_t size, void* mem_user_data);
+
+typedef struct uvwasi_mem_s {
+  void* mem_user_data;
+  uvwasi_malloc malloc;
+  uvwasi_free free;
+  uvwasi_calloc calloc;
+  uvwasi_realloc realloc;
+} uvwasi_mem_t;
 
 typedef struct uvwasi_s {
   struct uvwasi_fd_table_t fds;
@@ -33,6 +45,7 @@ typedef struct uvwasi_s {
   char** env;
   char* env_buf;
   size_t env_buf_size;
+  const uvwasi_mem_t* allocator;
 } uvwasi_t;
 
 typedef struct uvwasi_preopen_s {
@@ -47,8 +60,8 @@ typedef struct uvwasi_options_s {
   size_t argc;
   char** argv;
   char** envp;
+  const uvwasi_mem_t* allocator;
 } uvwasi_options_t;
-
 
 // Embedder API.
 uvwasi_errno_t uvwasi_init(uvwasi_t* uvwasi, uvwasi_options_t* options);

--- a/src/uvwasi_alloc.h
+++ b/src/uvwasi_alloc.h
@@ -1,0 +1,11 @@
+#ifndef __UVWASI_ALLOC_H__
+#define __UVWASI_ALLOC_H__
+
+#include "uvwasi.h"
+
+void* uvwasi__malloc(const uvwasi_t* uvwasi, size_t size);
+void uvwasi__free(const uvwasi_t* uvwasi, void* ptr);
+void* uvwasi__calloc(const uvwasi_t* uvwasi, size_t nmemb, size_t size);
+void* uvwasi__realloc(const uvwasi_t* uvwasi, void* ptr, size_t size);
+
+#endif

--- a/test/test-args-get.c
+++ b/test/test-args-get.c
@@ -21,6 +21,7 @@ int main(void) {
   init_options.envp = NULL;
   init_options.preopenc = 0;
   init_options.preopens = NULL;
+  init_options.allocator = NULL;
 
   err = uvwasi_init(&uvwasi, &init_options);
   assert(err == 0);

--- a/test/test-basic-file-io.c
+++ b/test/test-basic-file-io.c
@@ -37,6 +37,7 @@ int main(void) {
   init_options.preopens = calloc(1, sizeof(uvwasi_preopen_t));
   init_options.preopens[0].mapped_path = "/var";
   init_options.preopens[0].real_path = TEST_TMP_DIR;
+  init_options.allocator = NULL;
 
   err = uvwasi_init(&uvwasi, &init_options);
   assert(err == 0);

--- a/test/test-ebadf-input-validation.c
+++ b/test/test-ebadf-input-validation.c
@@ -28,6 +28,7 @@ int main(void) {
   init_options.envp = NULL;
   init_options.preopenc = 0;
   init_options.preopens = NULL;
+  init_options.allocator = NULL;
   err = uvwasi_init(&uvw, &init_options);
   assert(err == 0);
 

--- a/test/test-environ-get.c
+++ b/test/test-environ-get.c
@@ -26,6 +26,7 @@ int main(void) {
   init_options.envp = (char**) environ;
   init_options.preopenc = 0;
   init_options.preopens = NULL;
+  init_options.allocator = NULL;
 
   err = uvwasi_init(&uvwasi, &init_options);
   assert(err == 0);

--- a/test/test-fd-prestat-dir-name.c
+++ b/test/test-fd-prestat-dir-name.c
@@ -27,6 +27,7 @@ int main(void) {
   init_options.preopens = calloc(1, sizeof(uvwasi_preopen_t));
   init_options.preopens[0].mapped_path = "/var";
   init_options.preopens[0].real_path = TEST_TMP_DIR;
+  init_options.allocator = NULL;
 
   err = uvwasi_init(&uvwasi, &init_options);
   assert(err == 0);

--- a/test/test-path-create-remove-directory.c
+++ b/test/test-path-create-remove-directory.c
@@ -29,6 +29,7 @@ int main(void) {
   init_options.preopens = calloc(1, sizeof(uvwasi_preopen_t));
   init_options.preopens[0].mapped_path = "/var";
   init_options.preopens[0].real_path = TEST_TMP_DIR;
+  init_options.allocator = NULL;
 
   err = uvwasi_init(&uvwasi, &init_options);
   assert(err == 0);

--- a/test/test-random-get.c
+++ b/test/test-random-get.c
@@ -19,6 +19,7 @@ int main(void) {
   init_options.envp = NULL;
   init_options.preopenc = 0;
   init_options.preopens = NULL;
+  init_options.allocator = NULL;
 
   err = uvwasi_init(&uvwasi, &init_options);
   assert(err == 0);


### PR DESCRIPTION
This is a good idea for libraries in general, and helps with tracking
memory allocated by uvwasi in Node.js.

The allocator struct format is identical to the one used by nghttp2
and related libraries, which makes things a bit easier because we’ve
added generic support for that format in the QUIC repo.