### PR TITLE
support multiple calls to uvwasi_destroy()

### DIFF
--- a/test/test-multiple-wasi-destroys.c
+++ b/test/test-multiple-wasi-destroys.c
@@ -1,0 +1,26 @@
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+#include "uvwasi.h"
+
+int main(void) {
+  uvwasi_t uvwasi;
+  uvwasi_options_t init_options;
+  uvwasi_errno_t err;
+
+  init_options.fd_table_size = 3;
+  init_options.argc = 0;
+  init_options.argv = NULL;
+  init_options.envp = NULL;
+  init_options.preopenc = 0;
+  init_options.preopens = NULL;
+  init_options.allocator = NULL;
+
+  assert(0 == uvwasi_init(&uvwasi, &init_options));
+  /* Calling uvwasi_destroy() multiple times should be fine. */
+  uvwasi_destroy(&uvwasi);
+  uvwasi_destroy(&uvwasi);
+  uvwasi_destroy(&uvwasi);
+
+  return 0;
+}


### PR DESCRIPTION
This commit ensures that multiple calls to `uvwasi_destroy()` are possible. Prior to this commit, subsequent calls to destroy() would abort because the file table's rwlock was incorrectly being destroyed multiple times.