### PR TITLE
src: suppress warnings in uvwasi.c

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,6 @@ endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
   list(APPEND uvwasi_defines _GNU_SOURCE _POSIX_C_SOURCE=200112)
-  list(APPEND uvwasi_sources src/uvwasi.c)
 endif()
 
 include(FetchContent)
@@ -70,6 +69,7 @@ endif()
 
 ## Static library target.
 add_library(uvwasi_a STATIC ${uvwasi_sources})
+target_compile_definitions(uvwasi_a PRIVATE ${uvwasi_defines})
 target_compile_options(uvwasi_a PRIVATE ${uvwasi_cflags})
 target_include_directories(uvwasi_a PRIVATE ${PROJECT_SOURCE_DIR}/include)
 if(CODE_COVERAGE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,11 @@ if(APPLE)
    set(CMAKE_MACOSX_RPATH ON)
 endif()
 
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  list(APPEND uvwasi_defines _GNU_SOURCE _POSIX_C_SOURCE=200112)
+  list(APPEND uvwasi_sources src/unix/linux-core.c)
+endif()
+
 include(FetchContent)
 ## https://libuv.org
 FetchContent_Declare(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
   list(APPEND uvwasi_defines _GNU_SOURCE _POSIX_C_SOURCE=200112)
-  list(APPEND uvwasi_sources src/unix/linux-core.c)
+  list(APPEND uvwasi_sources src/uvwasi.c)
 endif()
 
 include(FetchContent)

--- a/src/uvwasi.c
+++ b/src/uvwasi.c
@@ -1,5 +1,4 @@
 #include <stdlib.h>
-#define _GNU_SOURCE
 #include <string.h>
 
 #ifndef _WIN32

--- a/src/uvwasi.c
+++ b/src/uvwasi.c
@@ -1,4 +1,5 @@
 #include <stdlib.h>
+#define _GNU_SOURCE
 #include <string.h>
 
 #ifndef _WIN32


### PR DESCRIPTION
Defined `_GNU_SOURCE` to suppress warnings
thrown during node build from scratch.

Refs: https://github.com/nodejs/node/pull/31139