### PR TITLE
fix '_lseeki64' undefined compiler warning

### DIFF
--- a/src/uvwasi.c
+++ b/src/uvwasi.c
@@ -11,6 +11,7 @@
 # define SLASH_STR "/"
 # define IS_SLASH(c) ((c) == '/')
 #else
+# include <io.h>
 # define SLASH '\\'
 # define SLASH_STR "\\"
 # define IS_SLASH(c) ((c) == '/' || (c) == '\\')


### PR DESCRIPTION
Thanks to work done by @gengjiawen (https://github.com/nodejs/node/pull/31153) we're now running Node.js tests as GitHub actions and this appears to be annotating pull requests in core with build warnings from unchanged files, one of which is from [`deps/uvwasi/src/uvwasi.c`](https://github.com/nodejs/node/pull/31300/checks?check_run_id=383837881#step:6:54):

![image](https://user-images.githubusercontent.com/5445507/72184831-3ce10d80-33e9-11ea-8e93-48986b9ee838.png)

The full warning, from https://github.com/cjihrig/uvwasi/runs/362355578#step:5:383:
```console
##[warning]D:\a\uvwasi\uvwasi\src\uvwasi.c(225,16): warning C4013: '_lseeki64' undefined; assuming extern returning int [D:\a\uvwasi\uvwasi\uvwasi_a.vcxproj]
```