### PR TITLE
reland "fix '_lseeki64' undefined compiler warning"

### DIFF
--- a/src/uvwasi.c
+++ b/src/uvwasi.c
@@ -9,6 +9,7 @@
 # include <time.h>
 # define IS_SLASH(c) ((c) == '/')
 #else
+# include <io.h>
 # define IS_SLASH(c) ((c) == '/' || (c) == '\\')
 #endif /* _WIN32 */
 


### PR DESCRIPTION
https://github.com/cjihrig/uvwasi/commit/20fd9e2 was accidentally reverted in https://github.com/cjihrig/uvwasi/pull/73. This commit relands it.