### PR TITLE
move fd renumbering into the fd table

### DIFF
--- a/include/fd_table.h
+++ b/include/fd_table.h
@@ -54,5 +54,9 @@ uvwasi_errno_t uvwasi_fd_table_get(const struct uvwasi_fd_table_t* table,
 uvwasi_errno_t uvwasi_fd_table_remove(struct uvwasi_s* uvwasi,
                                       struct uvwasi_fd_table_t* table,
                                       const uvwasi_fd_t id);
+uvwasi_errno_t uvwasi_fd_table_renumber(struct uvwasi_s* uvwasi,
+                                        struct uvwasi_fd_table_t* table,
+                                        const uvwasi_fd_t dst,
+                                        const uvwasi_fd_t src);
 
 #endif /* __UVWASI_FD_TABLE_H__ */

--- a/src/uvwasi.c
+++ b/src/uvwasi.c
@@ -1486,41 +1486,10 @@ exit:
 uvwasi_errno_t uvwasi_fd_renumber(uvwasi_t* uvwasi,
                                   uvwasi_fd_t from,
                                   uvwasi_fd_t to) {
-  struct uvwasi_fd_wrap_t* to_wrap;
-  struct uvwasi_fd_wrap_t* from_wrap;
-  uv_fs_t req;
-  uvwasi_errno_t err;
-  int r;
-
   if (uvwasi == NULL)
     return UVWASI_EINVAL;
 
-  if (from == to)
-    return UVWASI_ESUCCESS;
-
-  err = uvwasi_fd_table_get(&uvwasi->fds, from, &from_wrap, 0, 0);
-  if (err != UVWASI_ESUCCESS)
-    return err;
-
-  err = uvwasi_fd_table_get(&uvwasi->fds, to, &to_wrap, 0, 0);
-  if (err != UVWASI_ESUCCESS) {
-    uv_mutex_unlock(&from_wrap->mutex);
-    return err;
-  }
-
-  r = uv_fs_close(NULL, &req, to_wrap->fd, NULL);
-  uv_fs_req_cleanup(&req);
-  if (r != 0) {
-    uv_mutex_unlock(&from_wrap->mutex);
-    uv_mutex_unlock(&to_wrap->mutex);
-    return uvwasi__translate_uv_error(r);
-  }
-
-  memcpy(to_wrap, from_wrap, sizeof(*to_wrap));
-  to_wrap->id = to;
-  uv_mutex_unlock(&from_wrap->mutex);
-  uv_mutex_unlock(&to_wrap->mutex);
-  return uvwasi_fd_table_remove(uvwasi, &uvwasi->fds, from);
+  return uvwasi_fd_table_renumber(uvwasi, &uvwasi->fds, to, from);
 }
 
 


### PR DESCRIPTION
This commit moves the file descriptor renumbering operation into the file descriptor table code since it depends on performing several fd table operations, and uses its internals. The previous implementation was broken anyway.

CI seems fine. [Node CI](https://ci.nodejs.org/job/node-test-commit/34957/) with a [new test](https://github.com/cjihrig/node-1/commit/7002f80c0744f2a43887d62b9251d46da4cafd8f) for this functionality seems fine too.