### PR TITLE
unlock all fd mutexes in reverse order

### DIFF
--- a/src/fd_table.c
+++ b/src/fd_table.c
@@ -366,8 +366,8 @@ uvwasi_errno_t uvwasi_fd_table_renumber(struct uvwasi_s* uvwasi,
   r = uv_fs_close(NULL, &req, dst_entry->fd, NULL);
   uv_fs_req_cleanup(&req);
   if (r != 0) {
-    uv_mutex_unlock(&dst_entry->mutex);
     uv_mutex_unlock(&src_entry->mutex);
+    uv_mutex_unlock(&dst_entry->mutex);
     err = uvwasi__translate_uv_error(r);
     goto exit;
   }

--- a/src/uvwasi.c
+++ b/src/uvwasi.c
@@ -1821,9 +1821,9 @@ uvwasi_errno_t uvwasi_path_link(uvwasi_t* uvwasi,
 
   err = UVWASI_ESUCCESS;
 exit:
-  uv_mutex_unlock(&old_wrap->mutex);
+  uv_mutex_unlock(&new_wrap->mutex);
   if (old_fd != new_fd)
-    uv_mutex_unlock(&new_wrap->mutex);
+    uv_mutex_unlock(&old_wrap->mutex);
   return err;
 }
 
@@ -2136,9 +2136,9 @@ uvwasi_errno_t uvwasi_path_rename(uvwasi_t* uvwasi,
 
   err = UVWASI_ESUCCESS;
 exit:
-  uv_mutex_unlock(&old_wrap->mutex);
+  uv_mutex_unlock(&new_wrap->mutex);
   if (old_fd != new_fd)
-    uv_mutex_unlock(&new_wrap->mutex);
+    uv_mutex_unlock(&old_wrap->mutex);
 
   return err;
 }


### PR DESCRIPTION
Some functions acquire mutexes for multiple file descriptors.
This commit ensures that the mutexes are released in the
reverse order that they are acquired.

Refs: https://github.com/nodejs/node/pull/31432#pullrequestreview-345604137