### PR TITLE
prevent locking fd table while holding a mutex

### DIFF
--- a/include/fd_table.h
+++ b/include/fd_table.h
@@ -46,11 +46,16 @@ uvwasi_errno_t uvwasi_fd_table_insert_preopen(struct uvwasi_s* uvwasi,
                                               const uv_file fd,
                                               const char* path,
                                               const char* real_path);
-uvwasi_errno_t uvwasi_fd_table_get(const struct uvwasi_fd_table_t* table,
+uvwasi_errno_t uvwasi_fd_table_get(struct uvwasi_fd_table_t* table,
                                    const uvwasi_fd_t id,
                                    struct uvwasi_fd_wrap_t** wrap,
                                    uvwasi_rights_t rights_base,
                                    uvwasi_rights_t rights_inheriting);
+uvwasi_errno_t uvwasi_fd_table_get_nolock(struct uvwasi_fd_table_t* table,
+                                          const uvwasi_fd_t id,
+                                          struct uvwasi_fd_wrap_t** wrap,
+                                          uvwasi_rights_t rights_base,
+                                          uvwasi_rights_t rights_inheriting);
 uvwasi_errno_t uvwasi_fd_table_remove(struct uvwasi_s* uvwasi,
                                       struct uvwasi_fd_table_t* table,
                                       const uvwasi_fd_t id);
@@ -58,5 +63,7 @@ uvwasi_errno_t uvwasi_fd_table_renumber(struct uvwasi_s* uvwasi,
                                         struct uvwasi_fd_table_t* table,
                                         const uvwasi_fd_t dst,
                                         const uvwasi_fd_t src);
+uvwasi_errno_t uvwasi_fd_table_lock(struct uvwasi_fd_table_t* table);
+uvwasi_errno_t uvwasi_fd_table_unlock(struct uvwasi_fd_table_t* table);
 
 #endif /* __UVWASI_FD_TABLE_H__ */


### PR DESCRIPTION
`uvwasi_path_rename()`, `uvwasi_path_link()`, `uvwasi_path_open()`, and `uvwasi_fd_renumber()` operate on multiple file descriptors. `uvwasi_fd_renumber()` has been updated prior to this commit, and is not relevant here. The other three functions would perform
the following locking operations:

- lock the file table
- acquire a file descriptor mutex
- unlock the file table
- lock the file table again
- acquire another file descriptor mutex
- unlock the file table
- unlock the two mutexes

Attempting to acquire the second mutex introduced the possibility of deadlock because another thread could attempt to acquire the first mutex while holding the file table lock.

This commit ensures that multiple mutexes are either:
- acquired in a single lock of the file table
- or, only acquired after releasing previously held mutexes

Fixes: https://github.com/cjihrig/uvwasi/issues/89
Refs: https://github.com/nodejs/node/pull/31432#discussion_r368882784