### PR TITLE
prevent race conditions with uvwasi_fd_close()

### DIFF
--- a/include/fd_table.h
+++ b/include/fd_table.h
@@ -56,9 +56,9 @@ uvwasi_errno_t uvwasi_fd_table_get_nolock(struct uvwasi_fd_table_t* table,
                                           struct uvwasi_fd_wrap_t** wrap,
                                           uvwasi_rights_t rights_base,
                                           uvwasi_rights_t rights_inheriting);
-uvwasi_errno_t uvwasi_fd_table_remove(struct uvwasi_s* uvwasi,
-                                      struct uvwasi_fd_table_t* table,
-                                      const uvwasi_fd_t id);
+uvwasi_errno_t uvwasi_fd_table_remove_nolock(struct uvwasi_s* uvwasi,
+                                             struct uvwasi_fd_table_t* table,
+                                             const uvwasi_fd_t id);
 uvwasi_errno_t uvwasi_fd_table_renumber(struct uvwasi_s* uvwasi,
                                         struct uvwasi_fd_table_t* table,
                                         const uvwasi_fd_t dst,

--- a/src/fd_table.c
+++ b/src/fd_table.c
@@ -306,37 +306,27 @@ uvwasi_errno_t uvwasi_fd_table_get_nolock(struct uvwasi_fd_table_t* table,
 }
 
 
-uvwasi_errno_t uvwasi_fd_table_remove(uvwasi_t* uvwasi,
-                                      struct uvwasi_fd_table_t* table,
-                                      const uvwasi_fd_t id) {
+uvwasi_errno_t uvwasi_fd_table_remove_nolock(uvwasi_t* uvwasi,
+                                             struct uvwasi_fd_table_t* table,
+                                             const uvwasi_fd_t id) {
   struct uvwasi_fd_wrap_t* entry;
-  uvwasi_errno_t err;
 
   if (table == NULL)
     return UVWASI_EINVAL;
 
-  uv_rwlock_wrlock(&table->rwlock);
-
-  if (id >= table->size) {
-    err = UVWASI_EBADF;
-    goto exit;
-  }
+  if (id >= table->size)
+    return UVWASI_EBADF;
 
   entry = table->fds[id];
 
-  if (entry == NULL || entry->id != id) {
-    err = UVWASI_EBADF;
-    goto exit;
-  }
+  if (entry == NULL || entry->id != id)
+    return UVWASI_EBADF;
 
   uv_mutex_destroy(&entry->mutex);
   uvwasi__free(uvwasi, entry);
   table->fds[id] = NULL;
   table->used--;
-  err = UVWASI_ESUCCESS;
-exit:
-  uv_rwlock_wrunlock(&table->rwlock);
-  return err;
+  return UVWASI_ESUCCESS;
 }
 
 


### PR DESCRIPTION
This depends on https://github.com/cjihrig/uvwasi/pull/90 (the first commit in this PR).

`uvwasi_fd_close()` performed the following operations:

- lock the file descriptor mutex
- close the file
- release the file descriptor mutex
- call the file table's `remove()` function

Once the fd's mutex is released, another thread could acquire it
before the fd is removed from the file table. If this happens,
`remove()` could destroy a held mutex.

This commit updates `uvwasi_fd_close()` to perform the entire
sequence while holding the file table's lock, preventing new
acquisitions of the fd's mutex.

Fixes: https://github.com/cjihrig/uvwasi/issues/88