### PR TITLE
docs: add build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,17 @@
 `uvwasi` implements the [WASI][] system call API. Under the hood, `uvwasi`
 leverages [libuv][] where possible for maximum portability.
 
+## Building Locally
+
+To build with [CMake](https://cmake.org/):
+
+```sh
+$ mkdir -p out/cmake ; cd out/cmake   # create build directory
+$ cmake ../.. -DBUILD_TESTING=ON      # generate project with test
+$ cmake --build .                     # build
+$ ctest -C Debug --output-on-failure  # run tests
+```
+
 ## Example Usage
 
 ```c


### PR DESCRIPTION
This PR adds some basic build instructions for those who may not be familiar with CMake.

Happy to move these to another location in the repo if preferred!

cc @cjihrig 