### PR TITLE
src: add missing clocks header include

### DIFF
--- a/src/clocks.c
+++ b/src/clocks.c
@@ -6,6 +6,7 @@
 #endif /* _WIN32 */
 
 #include "uv.h"
+#include "clocks.h"
 #include "wasi_types.h"
 #include "uv_mapping.h"
 


### PR DESCRIPTION
`clocks.c` was missing the associated header file, so it caused errors in Electron like the following:

![Screen Shot 2020-02-14 at 3 04 17 PM](https://user-images.githubusercontent.com/2036040/74575306-52db7400-4f3b-11ea-9863-636eb663fef7.png)

This PR rectifies that by adding the missing header.

cc @cjihrig 