### PR TITLE
make stdio configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ int main(void) {
   uvwasi_errno_t err;
 
   /* Setup the initialization options. */
+  init_options.stdin = 0;
+  init_options.stdout = 1;
+  init_options.stderr = 2;
   init_options.fd_table_size = 3;
   init_options.argc = 3;
   init_options.argv = calloc(3, sizeof(char*));
@@ -38,6 +41,7 @@ int main(void) {
   init_options.preopens = calloc(1, sizeof(uvwasi_preopen_t));
   init_options.preopens[0].mapped_path = "/var";
   init_options.preopens[0].real_path = ".";
+  init_options.allocator = NULL;
 
   /* Initialize the sandbox. */
   err = uvwasi_init(&uvwasi, &init_options);
@@ -146,6 +150,10 @@ typedef struct uvwasi_options_s {
   size_t argc;
   char** argv;
   char** envp;
+  uvwasi_fd_t stdin;
+  uvwasi_fd_t stdout;
+  uvwasi_fd_t stderr;
+  const uvwasi_mem_t* allocator;
 } uvwasi_options_t;
 ```
 

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ int main(void) {
   uvwasi_errno_t err;
 
   /* Setup the initialization options. */
-  init_options.stdin = 0;
-  init_options.stdout = 1;
-  init_options.stderr = 2;
+  init_options.in = 0;
+  init_options.out = 1;
+  init_options.err = 2;
   init_options.fd_table_size = 3;
   init_options.argc = 3;
   init_options.argv = calloc(3, sizeof(char*));
@@ -150,9 +150,9 @@ typedef struct uvwasi_options_s {
   size_t argc;
   char** argv;
   char** envp;
-  uvwasi_fd_t stdin;
-  uvwasi_fd_t stdout;
-  uvwasi_fd_t stderr;
+  uvwasi_fd_t in;
+  uvwasi_fd_t out;
+  uvwasi_fd_t err;
   const uvwasi_mem_t* allocator;
 } uvwasi_options_t;
 ```

--- a/include/fd_table.h
+++ b/include/fd_table.h
@@ -6,6 +6,7 @@
 #include "wasi_types.h"
 
 struct uvwasi_s;
+struct uvwasi_options_s;
 
 struct uvwasi_fd_wrap_t {
   uvwasi_fd_t id;
@@ -27,8 +28,7 @@ struct uvwasi_fd_table_t {
 };
 
 uvwasi_errno_t uvwasi_fd_table_init(struct uvwasi_s* uvwasi,
-                                    struct uvwasi_fd_table_t* table,
-                                    uint32_t init_size);
+                                    struct uvwasi_options_s* options);
 void uvwasi_fd_table_free(struct uvwasi_s* uvwasi,
                           struct uvwasi_fd_table_t* table);
 uvwasi_errno_t uvwasi_fd_table_insert(struct uvwasi_s* uvwasi,

--- a/include/uvwasi.h
+++ b/include/uvwasi.h
@@ -60,6 +60,9 @@ typedef struct uvwasi_options_s {
   size_t argc;
   char** argv;
   char** envp;
+  uvwasi_fd_t stdin;
+  uvwasi_fd_t stdout;
+  uvwasi_fd_t stderr;
   const uvwasi_mem_t* allocator;
 } uvwasi_options_t;
 

--- a/include/uvwasi.h
+++ b/include/uvwasi.h
@@ -60,9 +60,9 @@ typedef struct uvwasi_options_s {
   size_t argc;
   char** argv;
   char** envp;
-  uvwasi_fd_t stdin;
-  uvwasi_fd_t stdout;
-  uvwasi_fd_t stderr;
+  uvwasi_fd_t in;
+  uvwasi_fd_t out;
+  uvwasi_fd_t err;
   const uvwasi_mem_t* allocator;
 } uvwasi_options_t;
 

--- a/src/fd_table.c
+++ b/src/fd_table.c
@@ -190,15 +190,15 @@ uvwasi_errno_t uvwasi_fd_table_init(uvwasi_t* uvwasi,
   }
 
   /* Create the stdio FDs. */
-  err = uvwasi__insert_stdio(uvwasi, table, options->stdin, 0, "<stdin>");
+  err = uvwasi__insert_stdio(uvwasi, table, options->in, 0, "<stdin>");
   if (err != UVWASI_ESUCCESS)
     goto error_exit;
 
-  err = uvwasi__insert_stdio(uvwasi, table, options->stdout, 1, "<stdout>");
+  err = uvwasi__insert_stdio(uvwasi, table, options->out, 1, "<stdout>");
   if (err != UVWASI_ESUCCESS)
     goto error_exit;
 
-  err = uvwasi__insert_stdio(uvwasi, table, options->stderr, 2, "<stderr>");
+  err = uvwasi__insert_stdio(uvwasi, table, options->err, 2, "<stderr>");
   if (err != UVWASI_ESUCCESS)
     goto error_exit;
 

--- a/src/fd_table.c
+++ b/src/fd_table.c
@@ -117,8 +117,8 @@ exit:
 
 
 uvwasi_errno_t uvwasi_fd_table_init(uvwasi_t* uvwasi,
-                                    struct uvwasi_fd_table_t* table,
-                                    uint32_t init_size) {
+                                    uvwasi_options_t* options) {
+  struct uvwasi_fd_table_t* table;
   struct uvwasi_fd_wrap_t* wrap;
   uvwasi_filetype_t type;
   uvwasi_rights_t base;
@@ -128,14 +128,15 @@ uvwasi_errno_t uvwasi_fd_table_init(uvwasi_t* uvwasi,
   int r;
 
   /* Require an initial size of at least three to store the stdio FDs. */
-  if (table == NULL || init_size < 3)
+  if (uvwasi == NULL || options == NULL || options->fd_table_size < 3)
     return UVWASI_EINVAL;
 
+  table = &uvwasi->fds;
   table->fds = NULL;
   table->used = 0;
-  table->size = init_size;
+  table->size = options->fd_table_size;
   table->fds = uvwasi__calloc(uvwasi,
-                              init_size,
+                              options->fd_table_size,
                               sizeof(struct uvwasi_fd_wrap_t*));
 
   if (table->fds == NULL)

--- a/src/fd_table.c
+++ b/src/fd_table.c
@@ -16,7 +16,7 @@
 
 static uvwasi_errno_t uvwasi__insert_stdio(uvwasi_t* uvwasi,
                                            struct uvwasi_fd_table_t* table,
-                                           const uv_file fd,
+                                           const uvwasi_fd_t fd,
                                            const uvwasi_fd_t expected,
                                            const char* name) {
   struct uvwasi_fd_wrap_t* wrap;
@@ -190,15 +190,15 @@ uvwasi_errno_t uvwasi_fd_table_init(uvwasi_t* uvwasi,
   }
 
   /* Create the stdio FDs. */
-  err = uvwasi__insert_stdio(uvwasi, table, 0, 0, "<stdin>");
+  err = uvwasi__insert_stdio(uvwasi, table, options->stdin, 0, "<stdin>");
   if (err != UVWASI_ESUCCESS)
     goto error_exit;
 
-  err = uvwasi__insert_stdio(uvwasi, table, 1, 1, "<stdout>");
+  err = uvwasi__insert_stdio(uvwasi, table, options->stdout, 1, "<stdout>");
   if (err != UVWASI_ESUCCESS)
     goto error_exit;
 
-  err = uvwasi__insert_stdio(uvwasi, table, 2, 2, "<stderr>");
+  err = uvwasi__insert_stdio(uvwasi, table, options->stderr, 2, "<stderr>");
   if (err != UVWASI_ESUCCESS)
     goto error_exit;
 

--- a/src/uvwasi.c
+++ b/src/uvwasi.c
@@ -574,7 +574,7 @@ uvwasi_errno_t uvwasi_init(uvwasi_t* uvwasi, uvwasi_options_t* options) {
     }
   }
 
-  err = uvwasi_fd_table_init(uvwasi, &uvwasi->fds, options->fd_table_size);
+  err = uvwasi_fd_table_init(uvwasi, options);
   if (err != UVWASI_ESUCCESS)
     goto exit;
 

--- a/test/test-args-get.c
+++ b/test/test-args-get.c
@@ -12,9 +12,9 @@ int main(void) {
   char** args_get_argv;
   char* buf;
 
-  init_options.stdin = 0;
-  init_options.stdout = 1;
-  init_options.stderr = 2;
+  init_options.in = 0;
+  init_options.out = 1;
+  init_options.err = 2;
   init_options.fd_table_size = 3;
   init_options.argc = 3;
   init_options.argv = calloc(3, sizeof(char*));

--- a/test/test-args-get.c
+++ b/test/test-args-get.c
@@ -12,6 +12,9 @@ int main(void) {
   char** args_get_argv;
   char* buf;
 
+  init_options.stdin = 0;
+  init_options.stdout = 1;
+  init_options.stderr = 2;
   init_options.fd_table_size = 3;
   init_options.argc = 3;
   init_options.argv = calloc(3, sizeof(char*));

--- a/test/test-basic-file-io.c
+++ b/test/test-basic-file-io.c
@@ -29,9 +29,9 @@ int main(void) {
   uv_fs_req_cleanup(&req);
   assert(r == 0 || r == UV_EEXIST);
 
-  init_options.stdin = 0;
-  init_options.stdout = 1;
-  init_options.stderr = 2;
+  init_options.in = 0;
+  init_options.out = 1;
+  init_options.err = 2;
   init_options.fd_table_size = 3;
   init_options.argc = 0;
   init_options.argv = NULL;

--- a/test/test-basic-file-io.c
+++ b/test/test-basic-file-io.c
@@ -29,6 +29,9 @@ int main(void) {
   uv_fs_req_cleanup(&req);
   assert(r == 0 || r == UV_EEXIST);
 
+  init_options.stdin = 0;
+  init_options.stdout = 1;
+  init_options.stderr = 2;
   init_options.fd_table_size = 3;
   init_options.argc = 0;
   init_options.argv = NULL;

--- a/test/test-ebadf-input-validation.c
+++ b/test/test-ebadf-input-validation.c
@@ -22,9 +22,9 @@ int main(void) {
 
   test_void = (void*) &test_fdstat;
 
-  init_options.stdin = 0;
-  init_options.stdout = 1;
-  init_options.stderr = 2;
+  init_options.in = 0;
+  init_options.out = 1;
+  init_options.err = 2;
   init_options.fd_table_size = 3;
   init_options.argc = 0;
   init_options.argv = NULL;

--- a/test/test-ebadf-input-validation.c
+++ b/test/test-ebadf-input-validation.c
@@ -22,6 +22,9 @@ int main(void) {
 
   test_void = (void*) &test_fdstat;
 
+  init_options.stdin = 0;
+  init_options.stdout = 1;
+  init_options.stderr = 2;
   init_options.fd_table_size = 3;
   init_options.argc = 0;
   init_options.argv = NULL;

--- a/test/test-environ-get.c
+++ b/test/test-environ-get.c
@@ -20,9 +20,9 @@ int main(void) {
   char* buf;
   size_t i;
 
-  init_options.stdin = 0;
-  init_options.stdout = 1;
-  init_options.stderr = 2;
+  init_options.in = 0;
+  init_options.out = 1;
+  init_options.err = 2;
   init_options.fd_table_size = 3;
   init_options.argc = 0;
   init_options.argv = NULL;

--- a/test/test-environ-get.c
+++ b/test/test-environ-get.c
@@ -20,6 +20,9 @@ int main(void) {
   char* buf;
   size_t i;
 
+  init_options.stdin = 0;
+  init_options.stdout = 1;
+  init_options.stderr = 2;
   init_options.fd_table_size = 3;
   init_options.argc = 0;
   init_options.argv = NULL;

--- a/test/test-fd-prestat-dir-name.c
+++ b/test/test-fd-prestat-dir-name.c
@@ -19,6 +19,9 @@ int main(void) {
   uv_fs_req_cleanup(&req);
   assert(r == 0 || r == UV_EEXIST);
 
+  init_options.stdin = 0;
+  init_options.stdout = 1;
+  init_options.stderr = 2;
   init_options.fd_table_size = 3;
   init_options.argc = 0;
   init_options.argv = NULL;

--- a/test/test-fd-prestat-dir-name.c
+++ b/test/test-fd-prestat-dir-name.c
@@ -19,9 +19,9 @@ int main(void) {
   uv_fs_req_cleanup(&req);
   assert(r == 0 || r == UV_EEXIST);
 
-  init_options.stdin = 0;
-  init_options.stdout = 1;
-  init_options.stderr = 2;
+  init_options.in = 0;
+  init_options.out = 1;
+  init_options.err = 2;
   init_options.fd_table_size = 3;
   init_options.argc = 0;
   init_options.argv = NULL;

--- a/test/test-multiple-wasi-destroys.c
+++ b/test/test-multiple-wasi-destroys.c
@@ -8,9 +8,9 @@ int main(void) {
   uvwasi_options_t init_options;
   uvwasi_errno_t err;
 
-  init_options.stdin = 0;
-  init_options.stdout = 1;
-  init_options.stderr = 2;
+  init_options.in = 0;
+  init_options.out = 1;
+  init_options.err = 2;
   init_options.fd_table_size = 3;
   init_options.argc = 0;
   init_options.argv = NULL;

--- a/test/test-multiple-wasi-destroys.c
+++ b/test/test-multiple-wasi-destroys.c
@@ -8,6 +8,9 @@ int main(void) {
   uvwasi_options_t init_options;
   uvwasi_errno_t err;
 
+  init_options.stdin = 0;
+  init_options.stdout = 1;
+  init_options.stderr = 2;
   init_options.fd_table_size = 3;
   init_options.argc = 0;
   init_options.argv = NULL;

--- a/test/test-path-create-remove-directory.c
+++ b/test/test-path-create-remove-directory.c
@@ -21,6 +21,9 @@ int main(void) {
   uv_fs_req_cleanup(&req);
   assert(r == 0 || r == UV_ENOENT);
 
+  init_options.stdin = 0;
+  init_options.stdout = 1;
+  init_options.stderr = 2;
   init_options.fd_table_size = 3;
   init_options.argc = 0;
   init_options.argv = NULL;

--- a/test/test-path-create-remove-directory.c
+++ b/test/test-path-create-remove-directory.c
@@ -21,9 +21,9 @@ int main(void) {
   uv_fs_req_cleanup(&req);
   assert(r == 0 || r == UV_ENOENT);
 
-  init_options.stdin = 0;
-  init_options.stdout = 1;
-  init_options.stderr = 2;
+  init_options.in = 0;
+  init_options.out = 1;
+  init_options.err = 2;
   init_options.fd_table_size = 3;
   init_options.argc = 0;
   init_options.argv = NULL;

--- a/test/test-random-get.c
+++ b/test/test-random-get.c
@@ -13,6 +13,9 @@ int main(void) {
   int success;
   int i;
 
+  init_options.stdin = 0;
+  init_options.stdout = 1;
+  init_options.stderr = 2;
   init_options.fd_table_size = 3;
   init_options.argc = 0;
   init_options.argv = NULL;

--- a/test/test-random-get.c
+++ b/test/test-random-get.c
@@ -13,9 +13,9 @@ int main(void) {
   int success;
   int i;
 
-  init_options.stdin = 0;
-  init_options.stdout = 1;
-  init_options.stderr = 2;
+  init_options.in = 0;
+  init_options.out = 1;
+  init_options.err = 2;
   init_options.fd_table_size = 3;
   init_options.argc = 0;
   init_options.argv = NULL;


### PR DESCRIPTION
This PR adds options to `uvwasi_init()` to allow setting the stdio file descriptors. This will allow embedders like Node.js to run multiple WASI applications in the same process without sharing stdio.

Unfortunately, Windows doesn't seem to like the use of the names `stdin`, `stdout`, and `stderr` as struct members, which is why I went with `in`, `out`, and `err`.