### PR TITLE
remove path length restrictions

### DIFF
--- a/src/path_resolver.h
+++ b/src/path_resolver.h
@@ -3,16 +3,6 @@
 
 #include "uvwasi.h"
 
-/* TODO(cjihrig): PATH_MAX_BYTES shouldn't be stack allocated. On Windows, paths
-   can be 32k long, and this PATH_MAX_BYTES is an artificial limitation. */
-#ifdef _WIN32
-/* MAX_PATH is in characters, not bytes. Make sure we have enough headroom. */
-# define PATH_MAX_BYTES (MAX_PATH * 4)
-#else
-# include <limits.h>
-# define PATH_MAX_BYTES (PATH_MAX)
-#endif
-
 uvwasi_errno_t uvwasi__normalize_path(const char* path,
                                       size_t path_len,
                                       char* normalized_path,
@@ -22,7 +12,7 @@ uvwasi_errno_t uvwasi__resolve_path(const uvwasi_t* uvwasi,
                                     const struct uvwasi_fd_wrap_t* fd,
                                     const char* path,
                                     size_t path_len,
-                                    char* resolved_path,
+                                    char** resolved_path,
                                     uvwasi_lookupflags_t flags);
 
 #endif /* __UVWASI_PATH_RESOLVER_H__ */

--- a/test/test-path-resolution.c
+++ b/test/test-path-resolution.c
@@ -24,14 +24,11 @@ static void check_normalize(char* path, char* expected) {
   assert(0 == strcmp(buffer, expected));
 }
 
-static uvwasi_errno_t check(char* fd_mp, char* fd_rp, char* path) {
+static uvwasi_errno_t check(char* fd_mp, char* fd_rp, char* path, char** res) {
   struct uvwasi_fd_wrap_t fd;
   uvwasi_errno_t err;
-  char* resolved;
   size_t len;
 
-  buffer[0] = '\0';
-  resolved = buffer;
   len = strlen(path);
   fd.id = 3;
   fd.fd = 3;
@@ -48,16 +45,22 @@ static uvwasi_errno_t check(char* fd_mp, char* fd_rp, char* path) {
                                strlen(fd_mp));
   if (err != UVWASI_ESUCCESS)
     return err;
-  return uvwasi__resolve_path(&uvwasi, &fd, path, len, resolved, 0);
+  return uvwasi__resolve_path(&uvwasi, &fd, path, len, res, 0);
 }
 
 static void pass(char* mp, char* rp, char* path, char* expected) {
-  assert(UVWASI_ESUCCESS == check(mp, rp, path));
-  assert(0 == strcmp(buffer, expected));
+  char* resolved;
+
+  assert(UVWASI_ESUCCESS == check(mp, rp, path, &resolved));
+  assert(0 == strcmp(resolved, expected));
+  free(resolved);
 }
 
 static void fail(char* mp, char* rp, char* path, uvwasi_errno_t expected) {
-  assert(expected == check(mp, rp, path));
+  char* resolved;
+
+  assert(expected == check(mp, rp, path, &resolved));
+  assert(resolved == NULL);
 }
 
 int main(void) {


### PR DESCRIPTION
This commit removes `PATH_MAX_BYTES` and all of the code that
relies on it. All paths are now dynamically allocated.

Fixes: https://github.com/cjihrig/uvwasi/issues/114