### PR TITLE
Make argv and envp options const

### DIFF
--- a/include/uvwasi.h
+++ b/include/uvwasi.h
@@ -58,8 +58,8 @@ typedef struct uvwasi_options_s {
   uvwasi_size_t preopenc;
   uvwasi_preopen_t* preopens;
   uvwasi_size_t argc;
-  char** argv;
-  char** envp;
+  const char** argv;
+  const char** envp;
   uvwasi_fd_t in;
   uvwasi_fd_t out;
   uvwasi_fd_t err;

--- a/test/test-environ-get.c
+++ b/test/test-environ-get.c
@@ -26,7 +26,7 @@ int main(void) {
   init_options.fd_table_size = 3;
   init_options.argc = 0;
   init_options.argv = NULL;
-  init_options.envp = (char**) environ;
+  init_options.envp = environ;
   init_options.preopenc = 0;
   init_options.preopens = NULL;
   init_options.allocator = NULL;


### PR DESCRIPTION
This allows users pass arrays of C string literals.