### PR TITLE
reset pointer to prevent memory corruption

### DIFF
--- a/src/path_resolver.c
+++ b/src/path_resolver.c
@@ -351,6 +351,7 @@ static uvwasi_errno_t uvwasi__resolve_path_to_host(
 
 #ifdef _WIN32
   /* Replace / with \ on Windows. */
+  res_path = *resolved_path;
   for (i = real_path_len; i < *resolved_len; i++) {
     if (res_path[i] == '/')
       res_path[i] = '\\';

--- a/test/test-path-resolution.c
+++ b/test/test-path-resolution.c
@@ -50,9 +50,24 @@ static uvwasi_errno_t check(char* fd_mp, char* fd_rp, char* path, char** res) {
 
 static void pass(char* mp, char* rp, char* path, char* expected) {
   char* resolved;
+  size_t res_len;
+  size_t i;
 
   assert(UVWASI_ESUCCESS == check(mp, rp, path, &resolved));
-  assert(0 == strcmp(resolved, expected));
+  res_len = strlen(resolved);
+  assert(res_len == strlen(expected));
+
+  for (i = 0; i < res_len + 1; i++) {
+#ifdef _WIN32
+    if (resolved[i] == '\\') {
+      assert(expected[i] == '/');
+      continue;
+    }
+#endif /* _WIN32 */
+
+    assert(resolved[i] == expected[i]);
+  }
+
   free(resolved);
 }
 


### PR DESCRIPTION
The code in `path_resolver.c` that replaces forward slashes with
backslashes on Windows did not work. It modified a chunk of
memory immediately following the memory it was meant to update.
This was leading to crashes on Windows in the Node.js test
suite ~1-2% of the time. This commit resets the pointer to the
correct location for the calculations.

Side note: this logic was broken and the slashes weren't actually
being updated, but the tests were still passing on Windows. This
logic might not really be needed after all?

Node.js stress test (4,000 runs spread across 4 windows machines): https://ci.nodejs.org/view/Stress/job/node-stress-single-test/73/ ✔️ 
Also resolves: https://github.com/nodejs/node/pull/33403