### PR TITLE
v0.0.9

### DIFF
--- a/include/uvwasi.h
+++ b/include/uvwasi.h
@@ -10,7 +10,7 @@ extern "C" {
 
 #define UVWASI_VERSION_MAJOR 0
 #define UVWASI_VERSION_MINOR 0
-#define UVWASI_VERSION_PATCH 8
+#define UVWASI_VERSION_PATCH 9
 #define UVWASI_VERSION_HEX ((UVWASI_VERSION_MAJOR << 16) | \
                             (UVWASI_VERSION_MINOR <<  8) | \
                             (UVWASI_VERSION_PATCH))


### PR DESCRIPTION
Notable changes:

- A `DEBUG()` macro and `UVWASI_DEBUG_LOG` build option have been
  added to improve debugging. (https://github.com/cjihrig/uvwasi/pull/113)
- Path length restrictions have been removed across the codebase. (https://github.com/cjihrig/uvwasi/pull/115)
- Initial support for `poll_oneoff()` has been added on all
  platforms. The implementation is based on `uv_poll_t`'s. (https://github.com/cjihrig/uvwasi/pull/117)
- A new `uvwasi_size_t` has been introduced across the WASI system
  call API. This provides consistent 32-bit `size_t`'s. (https://github.com/cjihrig/uvwasi/pull/121)
- The cmake test targets are now only generated if uvwasi is the
  root project to avoid conflicts with targets from embedders. (https://github.com/cjihrig/uvwasi/pull/120)
- `uv.h` has been removed from the public headers. (https://github.com/cjihrig/uvwasi/pull/122)
- A serialization/deserialization API has been added to simplify
  the process of working with WASM memory. This also hides many
  WASI <--> WASM interfacing implementation details from
  embedders. (https://github.com/cjihrig/uvwasi/pull/94) and (https://github.com/cjihrig/uvwasi/pull/126)
- A memory corruption bug on Windows related to path resolution
  has been fixed. (https://github.com/cjihrig/uvwasi/pull/127)