### PR TITLE
Fix handling of UVWASI_LOOKUP_SYMLINK_FOLLOW in uvwasi_path_filestat_get

### DIFF
--- a/src/uvwasi.c
+++ b/src/uvwasi.c
@@ -1530,7 +1530,7 @@ uvwasi_errno_t uvwasi_path_filestat_get(uvwasi_t* uvwasi,
   if (err != UVWASI_ESUCCESS)
     goto exit;
 
-  r = uv_fs_stat(NULL, &req, resolved_path, NULL);
+  r = uv_fs_lstat(NULL, &req, resolved_path, NULL);
   uvwasi__free(uvwasi, resolved_path);
   if (r != 0) {
     uv_fs_req_cleanup(&req);


### PR DESCRIPTION
If uvwasi_path_filestat_get the pathname is resolved by
uvwasi__resolve_path which honors the UVWASI_LOOKUP_SYMLINK_FOLLOW
flag.

Later we were we unconditionally calling  uv_fs_stat which always
follows symlinks.  Instead we want to unconditionally call uv_fs_lstat
which never follows them (since the resolution was already handled
by the preceding call to uvwasi__resolve_path).