### PR TITLE
test: remove unused variables

### DIFF
--- a/test/test-environ-get.c
+++ b/test/test-environ-get.c
@@ -18,7 +18,6 @@ int main(void) {
   uvwasi_size_t env_buf_size;
   char** env_get_env;
   char* buf;
-  uvwasi_size_t i;
 
   init_options.in = 0;
   init_options.out = 1;

--- a/test/test-multiple-wasi-destroys.c
+++ b/test/test-multiple-wasi-destroys.c
@@ -6,7 +6,6 @@
 int main(void) {
   uvwasi_t uvwasi;
   uvwasi_options_t init_options;
-  uvwasi_errno_t err;
 
   init_options.in = 0;
   init_options.out = 1;

--- a/test/test-path-resolution.c
+++ b/test/test-path-resolution.c
@@ -79,8 +79,6 @@ static void fail(char* mp, char* rp, char* path, uvwasi_errno_t expected) {
 }
 
 int main(void) {
-  uvwasi_errno_t err;
-
   init_options.in = 0;
   init_options.out = 1;
   init_options.err = 2;


### PR DESCRIPTION
When enabling all warnings the unused variables are reported:
```console
$ cmake .. -DCMAKE_C_FLAGS=-Wall
```