### PR TITLE
fix poll_oneoff ASAN error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.11)
 project (uvwasi LANGUAGES C)
 
 # This can be a commit hash or tag
-set(LIBUV_VERSION v1.37.0)
+set(LIBUV_VERSION v1.38.0)
 
 include(CMakeDependentOption)
 cmake_dependent_option(UVWASI_BUILD_TESTS

--- a/src/poll_oneoff.c
+++ b/src/poll_oneoff.c
@@ -114,6 +114,8 @@ uvwasi_errno_t uvwasi__poll_oneoff_state_cleanup(
   for (i = 0; i < state->handle_cnt; i++)
     uv_close((uv_handle_t*) &state->poll_handles[i], NULL);
 
+  uv_run(&state->loop, UV_RUN_NOWAIT);
+
   state->max_fds = 0;
   state->fdevent_cnt = 0;
   state->handle_cnt = 0;

--- a/test/test-poll-state-cleanup.c
+++ b/test/test-poll-state-cleanup.c
@@ -1,0 +1,32 @@
+#include <assert.h>
+#include "uvwasi.h"
+
+int main(void) {
+  uvwasi_t uvwasi;
+  uvwasi_options_t init_options;
+  uvwasi_subscription_t sub;
+  uvwasi_event_t event;
+  uvwasi_size_t nevents;
+  uvwasi_errno_t err;
+
+  uvwasi_options_init(&init_options);
+  err = uvwasi_init(&uvwasi, &init_options);
+  assert(err == 0);
+
+  sub.userdata = 42;
+  sub.type = UVWASI_EVENTTYPE_CLOCK;
+  sub.u.clock.clock_id = UVWASI_CLOCK_REALTIME;
+  sub.u.clock.timeout = 0;
+  sub.u.clock.precision = 1;
+  sub.u.clock.flags = 0;
+
+  err = uvwasi_poll_oneoff(&uvwasi, &sub, &event, 1, &nevents);
+  assert(err == 0);
+  assert(nevents == 1);
+  assert(event.userdata == 42);
+  assert(event.error == UVWASI_ESUCCESS);
+  assert(event.type == UVWASI_EVENTTYPE_CLOCK);
+
+  uvwasi_destroy(&uvwasi);
+  return 0;
+}


### PR DESCRIPTION
This PR resolves an ASAN error in `poll_oneoff()`. It also includes the libuv 1.38.0 update in a separate commit.