### PR TITLE
add uvwasi_options_init()

### DIFF
--- a/include/uvwasi.h
+++ b/include/uvwasi.h
@@ -70,6 +70,7 @@ typedef struct uvwasi_options_s {
 /* Embedder API. */
 uvwasi_errno_t uvwasi_init(uvwasi_t* uvwasi, uvwasi_options_t* options);
 void uvwasi_destroy(uvwasi_t* uvwasi);
+void uvwasi_options_init(uvwasi_options_t* options);
 /* Use int instead of uv_file to avoid needing uv.h */
 uvwasi_errno_t uvwasi_embedder_remap_fd(uvwasi_t* uvwasi,
                                         const uvwasi_fd_t fd,

--- a/src/uvwasi.c
+++ b/src/uvwasi.c
@@ -308,6 +308,23 @@ void uvwasi_destroy(uvwasi_t* uvwasi) {
 }
 
 
+void uvwasi_options_init(uvwasi_options_t* options) {
+  if (options == NULL)
+    return;
+
+  options->in = 0;
+  options->out = 1;
+  options->err = 2;
+  options->fd_table_size = 3;
+  options->argc = 0;
+  options->argv = NULL;
+  options->envp = NULL;
+  options->preopenc = 0;
+  options->preopens = NULL;
+  options->allocator = NULL;
+}
+
+
 uvwasi_errno_t uvwasi_embedder_remap_fd(uvwasi_t* uvwasi,
                                         const uvwasi_fd_t fd,
                                         uv_file new_host_fd) {

--- a/test/test-args-get.c
+++ b/test/test-args-get.c
@@ -12,19 +12,12 @@ int main(void) {
   char** args_get_argv;
   char* buf;
 
-  init_options.in = 0;
-  init_options.out = 1;
-  init_options.err = 2;
-  init_options.fd_table_size = 3;
+  uvwasi_options_init(&init_options);
   init_options.argc = 3;
   init_options.argv = calloc(3, sizeof(char*));
   init_options.argv[0] = "--foo=bar";
   init_options.argv[1] = "-baz";
   init_options.argv[2] = "100";
-  init_options.envp = NULL;
-  init_options.preopenc = 0;
-  init_options.preopens = NULL;
-  init_options.allocator = NULL;
 
   err = uvwasi_init(&uvwasi, &init_options);
   assert(err == 0);

--- a/test/test-basic-file-io.c
+++ b/test/test-basic-file-io.c
@@ -31,18 +31,11 @@ int main(void) {
   uv_fs_req_cleanup(&req);
   assert(r == 0 || r == UV_EEXIST);
 
-  init_options.in = 0;
-  init_options.out = 1;
-  init_options.err = 2;
-  init_options.fd_table_size = 3;
-  init_options.argc = 0;
-  init_options.argv = NULL;
-  init_options.envp = NULL;
+  uvwasi_options_init(&init_options);
   init_options.preopenc = 1;
   init_options.preopens = calloc(1, sizeof(uvwasi_preopen_t));
   init_options.preopens[0].mapped_path = "/var";
   init_options.preopens[0].real_path = TEST_TMP_DIR;
-  init_options.allocator = NULL;
 
   err = uvwasi_init(&uvwasi, &init_options);
   assert(err == 0);

--- a/test/test-ebadf-input-validation.c
+++ b/test/test-ebadf-input-validation.c
@@ -22,16 +22,7 @@ int main(void) {
 
   test_void = (void*) &test_fdstat;
 
-  init_options.in = 0;
-  init_options.out = 1;
-  init_options.err = 2;
-  init_options.fd_table_size = 3;
-  init_options.argc = 0;
-  init_options.argv = NULL;
-  init_options.envp = NULL;
-  init_options.preopenc = 0;
-  init_options.preopens = NULL;
-  init_options.allocator = NULL;
+  uvwasi_options_init(&init_options);
   err = uvwasi_init(&uvw, &init_options);
   assert(err == 0);
 

--- a/test/test-environ-get.c
+++ b/test/test-environ-get.c
@@ -19,16 +19,8 @@ int main(void) {
   char** env_get_env;
   char* buf;
 
-  init_options.in = 0;
-  init_options.out = 1;
-  init_options.err = 2;
-  init_options.fd_table_size = 3;
-  init_options.argc = 0;
-  init_options.argv = NULL;
+  uvwasi_options_init(&init_options);
   init_options.envp = (const char**) environ;
-  init_options.preopenc = 0;
-  init_options.preopens = NULL;
-  init_options.allocator = NULL;
 
   err = uvwasi_init(&uvwasi, &init_options);
   assert(err == 0);

--- a/test/test-fd-prestat-dir-name.c
+++ b/test/test-fd-prestat-dir-name.c
@@ -20,18 +20,11 @@ int main(void) {
   uv_fs_req_cleanup(&req);
   assert(r == 0 || r == UV_EEXIST);
 
-  init_options.in = 0;
-  init_options.out = 1;
-  init_options.err = 2;
-  init_options.fd_table_size = 3;
-  init_options.argc = 0;
-  init_options.argv = NULL;
-  init_options.envp = NULL;
+  uvwasi_options_init(&init_options);
   init_options.preopenc = 1;
   init_options.preopens = calloc(1, sizeof(uvwasi_preopen_t));
   init_options.preopens[0].mapped_path = "/var";
   init_options.preopens[0].real_path = TEST_TMP_DIR;
-  init_options.allocator = NULL;
 
   err = uvwasi_init(&uvwasi, &init_options);
   assert(err == 0);

--- a/test/test-multiple-wasi-destroys.c
+++ b/test/test-multiple-wasi-destroys.c
@@ -7,16 +7,17 @@ int main(void) {
   uvwasi_t uvwasi;
   uvwasi_options_t init_options;
 
-  init_options.in = 0;
-  init_options.out = 1;
-  init_options.err = 2;
-  init_options.fd_table_size = 3;
-  init_options.argc = 0;
-  init_options.argv = NULL;
-  init_options.envp = NULL;
-  init_options.preopenc = 0;
-  init_options.preopens = NULL;
-  init_options.allocator = NULL;
+  uvwasi_options_init(&init_options);
+  assert(init_options.in == 0);
+  assert(init_options.out == 1);
+  assert(init_options.err == 2);
+  assert(init_options.fd_table_size == 3);
+  assert(init_options.argc == 0);
+  assert(init_options.argv == NULL);
+  assert(init_options.envp == NULL);
+  assert(init_options.preopenc == 0);
+  assert(init_options.preopens == NULL);
+  assert(init_options.allocator == NULL);
 
   assert(0 == uvwasi_init(&uvwasi, &init_options));
   /* Calling uvwasi_destroy() multiple times should be fine. */

--- a/test/test-path-create-remove-directory.c
+++ b/test/test-path-create-remove-directory.c
@@ -22,18 +22,11 @@ int main(void) {
   uv_fs_req_cleanup(&req);
   assert(r == 0 || r == UV_ENOENT);
 
-  init_options.in = 0;
-  init_options.out = 1;
-  init_options.err = 2;
-  init_options.fd_table_size = 3;
-  init_options.argc = 0;
-  init_options.argv = NULL;
-  init_options.envp = NULL;
+  uvwasi_options_init(&init_options);
   init_options.preopenc = 1;
   init_options.preopens = calloc(1, sizeof(uvwasi_preopen_t));
   init_options.preopens[0].mapped_path = "/var";
   init_options.preopens[0].real_path = TEST_TMP_DIR;
-  init_options.allocator = NULL;
 
   err = uvwasi_init(&uvwasi, &init_options);
   assert(err == 0);

--- a/test/test-path-resolution.c
+++ b/test/test-path-resolution.c
@@ -79,16 +79,7 @@ static void fail(char* mp, char* rp, char* path, uvwasi_errno_t expected) {
 }
 
 int main(void) {
-  init_options.in = 0;
-  init_options.out = 1;
-  init_options.err = 2;
-  init_options.fd_table_size = 3;
-  init_options.argc = 0;
-  init_options.argv = NULL;
-  init_options.envp = NULL;
-  init_options.preopenc = 0;
-  init_options.preopens = NULL;
-  init_options.allocator = NULL;
+  uvwasi_options_init(&init_options);
   assert(0 == uvwasi_init(&uvwasi, &init_options));
 
   /* Arguments: input path, expected normalized path */

--- a/test/test-random-get.c
+++ b/test/test-random-get.c
@@ -13,17 +13,7 @@ int main(void) {
   int success;
   int i;
 
-  init_options.in = 0;
-  init_options.out = 1;
-  init_options.err = 2;
-  init_options.fd_table_size = 3;
-  init_options.argc = 0;
-  init_options.argv = NULL;
-  init_options.envp = NULL;
-  init_options.preopenc = 0;
-  init_options.preopens = NULL;
-  init_options.allocator = NULL;
-
+  uvwasi_options_init(&init_options);
   err = uvwasi_init(&uvwasi, &init_options);
   assert(err == 0);
 


### PR DESCRIPTION
This commit adds a convenience function, `uvwasi_options_init()`, to initialize `uvwasi_options_t` structs to default values.

Refs: https://github.com/cjihrig/uvwasi/pull/140#discussion_r429555587