### PR TITLE
rename DEBUG() macro to UVWASI_DEBUG()

### DIFF
--- a/src/debug.h
+++ b/src/debug.h
@@ -6,10 +6,10 @@
 # define __STDC_FORMAT_MACROS
 #endif
 # include <inttypes.h>
-# define DEBUG(fmt, ...)                                                      \
+# define UVWASI_DEBUG(fmt, ...)                                                      \
     do { fprintf(stderr, fmt, __VA_ARGS__); } while (0)
 #else
-# define DEBUG(fmt, ...)
+# define UVWASI_DEBUG(fmt, ...)
 #endif
 
 #endif /* __UVWASI_DEBUG_H__ */

--- a/src/uvwasi.c
+++ b/src/uvwasi.c
@@ -419,10 +419,10 @@ uvwasi_errno_t uvwasi_embedder_remap_fd(uvwasi_t* uvwasi,
 uvwasi_errno_t uvwasi_args_get(uvwasi_t* uvwasi, char** argv, char* argv_buf) {
   uvwasi_size_t i;
 
-  DEBUG("uvwasi_args_get(uvwasi=%p, argv=%p, argv_buf=%p)\n",
-        uvwasi,
-        argv,
-        argv_buf);
+  UVWASI_DEBUG("uvwasi_args_get(uvwasi=%p, argv=%p, argv_buf=%p)\n",
+               uvwasi,
+               argv,
+               argv_buf);
 
   if (uvwasi == NULL || argv == NULL || argv_buf == NULL)
     return UVWASI_EINVAL;
@@ -439,10 +439,10 @@ uvwasi_errno_t uvwasi_args_get(uvwasi_t* uvwasi, char** argv, char* argv_buf) {
 uvwasi_errno_t uvwasi_args_sizes_get(uvwasi_t* uvwasi,
                                      uvwasi_size_t* argc,
                                      uvwasi_size_t* argv_buf_size) {
-  DEBUG("uvwasi_args_sizes_get(uvwasi=%p, argc=%p, argv_buf_size=%p)\n",
-        uvwasi,
-        argc,
-        argv_buf_size);
+  UVWASI_DEBUG("uvwasi_args_sizes_get(uvwasi=%p, argc=%p, argv_buf_size=%p)\n",
+               uvwasi,
+               argc,
+               argv_buf_size);
 
   if (uvwasi == NULL || argc == NULL || argv_buf_size == NULL)
     return UVWASI_EINVAL;
@@ -456,10 +456,10 @@ uvwasi_errno_t uvwasi_args_sizes_get(uvwasi_t* uvwasi,
 uvwasi_errno_t uvwasi_clock_res_get(uvwasi_t* uvwasi,
                                     uvwasi_clockid_t clock_id,
                                     uvwasi_timestamp_t* resolution) {
-  DEBUG("uvwasi_clock_res_get(uvwasi=%p, clock_id=%d, resolution=%p)\n",
-        uvwasi,
-        clock_id,
-        resolution);
+  UVWASI_DEBUG("uvwasi_clock_res_get(uvwasi=%p, clock_id=%d, resolution=%p)\n",
+               uvwasi,
+               clock_id,
+               resolution);
 
   if (uvwasi == NULL || resolution == NULL)
     return UVWASI_EINVAL;
@@ -483,12 +483,12 @@ uvwasi_errno_t uvwasi_clock_time_get(uvwasi_t* uvwasi,
                                      uvwasi_clockid_t clock_id,
                                      uvwasi_timestamp_t precision,
                                      uvwasi_timestamp_t* time) {
-  DEBUG("uvwasi_clock_time_get(uvwasi=%p, clock_id=%d, "
-        "precision=%"PRIu64", time=%p)\n",
-        uvwasi,
-        clock_id,
-        precision,
-        time);
+  UVWASI_DEBUG("uvwasi_clock_time_get(uvwasi=%p, clock_id=%d, "
+               "precision=%"PRIu64", time=%p)\n",
+               uvwasi,
+               clock_id,
+               precision,
+               time);
 
   if (uvwasi == NULL || time == NULL)
     return UVWASI_EINVAL;
@@ -514,10 +514,11 @@ uvwasi_errno_t uvwasi_environ_get(uvwasi_t* uvwasi,
                                   char* environ_buf) {
   uvwasi_size_t i;
 
-  DEBUG("uvwasi_environ_get(uvwasi=%p, environment=%p, environ_buf=%p)\n",
-        uvwasi,
-        environment,
-        environ_buf);
+  UVWASI_DEBUG("uvwasi_environ_get(uvwasi=%p, environment=%p, "
+               "environ_buf=%p)\n",
+               uvwasi,
+               environment,
+               environ_buf);
 
   if (uvwasi == NULL || environment == NULL || environ_buf == NULL)
     return UVWASI_EINVAL;
@@ -534,11 +535,11 @@ uvwasi_errno_t uvwasi_environ_get(uvwasi_t* uvwasi,
 uvwasi_errno_t uvwasi_environ_sizes_get(uvwasi_t* uvwasi,
                                         uvwasi_size_t* environ_count,
                                         uvwasi_size_t* environ_buf_size) {
-  DEBUG("uvwasi_environ_sizes_get(uvwasi=%p, environ_count=%p, "
-        "environ_buf_size=%p)\n",
-        uvwasi,
-        environ_count,
-        environ_buf_size);
+  UVWASI_DEBUG("uvwasi_environ_sizes_get(uvwasi=%p, environ_count=%p, "
+               "environ_buf_size=%p)\n",
+               uvwasi,
+               environ_count,
+               environ_buf_size);
 
   if (uvwasi == NULL || environ_count == NULL || environ_buf_size == NULL)
     return UVWASI_EINVAL;
@@ -561,13 +562,13 @@ uvwasi_errno_t uvwasi_fd_advise(uvwasi_t* uvwasi,
   int r;
 #endif /* POSIX_FADV_NORMAL */
 
-  DEBUG("uvwasi_fd_advise(uvwasi=%p, fd=%d, offset=%"PRIu64", len=%"PRIu64", "
-        "advice=%d)\n",
-        uvwasi,
-        fd,
-        offset,
-        len,
-        advice);
+  UVWASI_DEBUG("uvwasi_fd_advise(uvwasi=%p, fd=%d, offset=%"PRIu64", "
+               "len=%"PRIu64", advice=%d)\n",
+               uvwasi,
+               fd,
+               offset,
+               len,
+               advice);
 
   if (uvwasi == NULL)
     return UVWASI_EINVAL;
@@ -635,12 +636,12 @@ uvwasi_errno_t uvwasi_fd_allocate(uvwasi_t* uvwasi,
   uvwasi_errno_t err;
   int r;
 
-  DEBUG("uvwasi_fd_allocate(uvwasi=%p, fd=%d, offset=%"PRIu64", "
-        "len=%"PRIu64")\n",
-        uvwasi,
-        fd,
-        offset,
-        len);
+  UVWASI_DEBUG("uvwasi_fd_allocate(uvwasi=%p, fd=%d, offset=%"PRIu64", "
+               "len=%"PRIu64")\n",
+               uvwasi,
+               fd,
+               offset,
+               len);
 
   if (uvwasi == NULL)
     return UVWASI_EINVAL;
@@ -692,7 +693,7 @@ uvwasi_errno_t uvwasi_fd_close(uvwasi_t* uvwasi, uvwasi_fd_t fd) {
   uv_fs_t req;
   int r;
 
-  DEBUG("uvwasi_fd_close(uvwasi=%p, fd=%d)\n", uvwasi, fd);
+  UVWASI_DEBUG("uvwasi_fd_close(uvwasi=%p, fd=%d)\n", uvwasi, fd);
 
   if (uvwasi == NULL)
     return UVWASI_EINVAL;
@@ -726,7 +727,7 @@ uvwasi_errno_t uvwasi_fd_datasync(uvwasi_t* uvwasi, uvwasi_fd_t fd) {
   uv_fs_t req;
   int r;
 
-  DEBUG("uvwasi_fd_datasync(uvwasi=%p, fd=%d)\n", uvwasi, fd);
+  UVWASI_DEBUG("uvwasi_fd_datasync(uvwasi=%p, fd=%d)\n", uvwasi, fd);
 
   if (uvwasi == NULL)
     return UVWASI_EINVAL;
@@ -759,7 +760,10 @@ uvwasi_errno_t uvwasi_fd_fdstat_get(uvwasi_t* uvwasi,
   int r;
 #endif
 
-  DEBUG("uvwasi_fd_fdstat_get(uvwasi=%p, fd=%d, buf=%p)\n", uvwasi, fd, buf);
+  UVWASI_DEBUG("uvwasi_fd_fdstat_get(uvwasi=%p, fd=%d, buf=%p)\n",
+               uvwasi,
+               fd,
+               buf);
 
   if (uvwasi == NULL || buf == NULL)
     return UVWASI_EINVAL;
@@ -792,10 +796,10 @@ uvwasi_errno_t uvwasi_fd_fdstat_set_flags(uvwasi_t* uvwasi,
                                           uvwasi_fd_t fd,
                                           uvwasi_fdflags_t flags) {
 #ifdef _WIN32
-  DEBUG("uvwasi_fd_fdstat_set_flags(uvwasi=%p, fd=%d, flags=%d)\n",
-        uvwasi,
-        fd,
-        flags);
+  UVWASI_DEBUG("uvwasi_fd_fdstat_set_flags(uvwasi=%p, fd=%d, flags=%d)\n",
+               uvwasi,
+               fd,
+               flags);
 
   /* TODO(cjihrig): Windows is not supported. */
   return UVWASI_ENOSYS;
@@ -805,10 +809,10 @@ uvwasi_errno_t uvwasi_fd_fdstat_set_flags(uvwasi_t* uvwasi,
   int mapped_flags;
   int r;
 
-  DEBUG("uvwasi_fd_fdstat_set_flags(uvwasi=%p, fd=%d, flags=%d)\n",
-        uvwasi,
-        fd,
-        flags);
+  UVWASI_DEBUG("uvwasi_fd_fdstat_set_flags(uvwasi=%p, fd=%d, flags=%d)\n",
+               uvwasi,
+               fd,
+               flags);
 
   if (uvwasi == NULL)
     return UVWASI_EINVAL;
@@ -866,12 +870,12 @@ uvwasi_errno_t uvwasi_fd_fdstat_set_rights(uvwasi_t* uvwasi,
   struct uvwasi_fd_wrap_t* wrap;
   uvwasi_errno_t err;
 
-  DEBUG("uvwasi_fd_fdstat_set_rights(uvwasi=%p, fd=%d, "
-        "fs_rights_base=%"PRIu64", fs_rights_inheriting=%"PRIu64")\n",
-        uvwasi,
-        fd,
-        fs_rights_base,
-        fs_rights_inheriting);
+  UVWASI_DEBUG("uvwasi_fd_fdstat_set_rights(uvwasi=%p, fd=%d, "
+               "fs_rights_base=%"PRIu64", fs_rights_inheriting=%"PRIu64")\n",
+               uvwasi,
+               fd,
+               fs_rights_base,
+               fs_rights_inheriting);
 
   if (uvwasi == NULL)
     return UVWASI_EINVAL;
@@ -909,7 +913,10 @@ uvwasi_errno_t uvwasi_fd_filestat_get(uvwasi_t* uvwasi,
   uvwasi_errno_t err;
   int r;
 
-  DEBUG("uvwasi_fd_filestat_get(uvwasi=%p, fd=%d, buf=%p)\n", uvwasi, fd, buf);
+  UVWASI_DEBUG("uvwasi_fd_filestat_get(uvwasi=%p, fd=%d, buf=%p)\n",
+               uvwasi,
+               fd,
+               buf);
 
   if (uvwasi == NULL || buf == NULL)
     return UVWASI_EINVAL;
@@ -946,10 +953,11 @@ uvwasi_errno_t uvwasi_fd_filestat_set_size(uvwasi_t* uvwasi,
   uvwasi_errno_t err;
   int r;
 
-  DEBUG("uvwasi_fd_filestat_set_size(uvwasi=%p, fd=%d, st_size=%"PRIu64")\n",
-        uvwasi,
-        fd,
-        st_size);
+  UVWASI_DEBUG("uvwasi_fd_filestat_set_size(uvwasi=%p, fd=%d, "
+               "st_size=%"PRIu64")\n",
+               uvwasi,
+               fd,
+               st_size);
 
   if (uvwasi == NULL)
     return UVWASI_EINVAL;
@@ -985,13 +993,13 @@ uvwasi_errno_t uvwasi_fd_filestat_set_times(uvwasi_t* uvwasi,
   uvwasi_errno_t err;
   int r;
 
-  DEBUG("uvwasi_fd_filestat_set_times(uvwasi=%p, fd=%d, st_atim=%"PRIu64", "
-        "st_mtim=%"PRIu64", fst_flags=%d)\n",
-        uvwasi,
-        fd,
-        st_atim,
-        st_mtim,
-        fst_flags);
+  UVWASI_DEBUG("uvwasi_fd_filestat_set_times(uvwasi=%p, fd=%d, "
+               "st_atim=%"PRIu64", st_mtim=%"PRIu64", fst_flags=%d)\n",
+               uvwasi,
+               fd,
+               st_atim,
+               st_mtim,
+               fst_flags);
 
   if (uvwasi == NULL)
     return UVWASI_EINVAL;
@@ -1043,14 +1051,14 @@ uvwasi_errno_t uvwasi_fd_pread(uvwasi_t* uvwasi,
   size_t uvread;
   int r;
 
-  DEBUG("uvwasi_fd_pread(uvwasi=%p, fd=%d, iovs=%p, iovs_len=%d, "
-        "offset=%"PRIu64", nread=%p)\n",
-        uvwasi,
-        fd,
-        iovs,
-        iovs_len,
-        offset,
-        nread);
+  UVWASI_DEBUG("uvwasi_fd_pread(uvwasi=%p, fd=%d, iovs=%p, iovs_len=%d, "
+               "offset=%"PRIu64", nread=%p)\n",
+               uvwasi,
+               fd,
+               iovs,
+               iovs_len,
+               offset,
+               nread);
 
   if (uvwasi == NULL || iovs == NULL || nread == NULL)
     return UVWASI_EINVAL;
@@ -1089,10 +1097,10 @@ uvwasi_errno_t uvwasi_fd_prestat_get(uvwasi_t* uvwasi,
   struct uvwasi_fd_wrap_t* wrap;
   uvwasi_errno_t err;
 
-  DEBUG("uvwasi_fd_prestat_get(uvwasi=%p, fd=%d, buf=%p)\n",
-        uvwasi,
-        fd,
-        buf);
+  UVWASI_DEBUG("uvwasi_fd_prestat_get(uvwasi=%p, fd=%d, buf=%p)\n",
+               uvwasi,
+               fd,
+               buf);
 
   if (uvwasi == NULL || buf == NULL)
     return UVWASI_EINVAL;
@@ -1122,11 +1130,12 @@ uvwasi_errno_t uvwasi_fd_prestat_dir_name(uvwasi_t* uvwasi,
   uvwasi_errno_t err;
   size_t size;
 
-  DEBUG("uvwasi_fd_prestat_dir_name(uvwasi=%p, fd=%d, path=%p, path_len=%d)\n",
-        uvwasi,
-        fd,
-        path,
-        path_len);
+  UVWASI_DEBUG("uvwasi_fd_prestat_dir_name(uvwasi=%p, fd=%d, path=%p, "
+               "path_len=%d)\n",
+               uvwasi,
+               fd,
+               path,
+               path_len);
 
   if (uvwasi == NULL || path == NULL)
     return UVWASI_EINVAL;
@@ -1166,14 +1175,14 @@ uvwasi_errno_t uvwasi_fd_pwrite(uvwasi_t* uvwasi,
   size_t uvwritten;
   int r;
 
-  DEBUG("uvwasi_fd_pwrite(uvwasi=%p, fd=%d, iovs=%p, iovs_len=%d, "
-        "offset=%"PRIu64", nwritten=%p)\n",
-        uvwasi,
-        fd,
-        iovs,
-        iovs_len,
-        offset,
-        nwritten);
+  UVWASI_DEBUG("uvwasi_fd_pwrite(uvwasi=%p, fd=%d, iovs=%p, iovs_len=%d, "
+               "offset=%"PRIu64", nwritten=%p)\n",
+               uvwasi,
+               fd,
+               iovs,
+               iovs_len,
+               offset,
+               nwritten);
 
   if (uvwasi == NULL || iovs == NULL || nwritten == NULL)
     return UVWASI_EINVAL;
@@ -1218,12 +1227,13 @@ uvwasi_errno_t uvwasi_fd_read(uvwasi_t* uvwasi,
   size_t uvread;
   int r;
 
-  DEBUG("uvwasi_fd_read(uvwasi=%p, fd=%d, iovs=%p, iovs_len=%d, nread=%p)\n",
-        uvwasi,
-        fd,
-        iovs,
-        iovs_len,
-        nread);
+  UVWASI_DEBUG("uvwasi_fd_read(uvwasi=%p, fd=%d, iovs=%p, iovs_len=%d, "
+               "nread=%p)\n",
+               uvwasi,
+               fd,
+               iovs,
+               iovs_len,
+               nread);
 
   if (uvwasi == NULL || iovs == NULL || nread == NULL)
     return UVWASI_EINVAL;
@@ -1273,14 +1283,14 @@ uvwasi_errno_t uvwasi_fd_readdir(uvwasi_t* uvwasi,
   int i;
   int r;
 
-  DEBUG("uvwasi_fd_readdir(uvwasi=%p, fd=%d, buf=%p, buf_len=%d, "
-        "cookie=%"PRIu64", bufused=%p)\n",
-        uvwasi,
-        fd,
-        buf,
-        buf_len,
-        cookie,
-        bufused);
+  UVWASI_DEBUG("uvwasi_fd_readdir(uvwasi=%p, fd=%d, buf=%p, buf_len=%d, "
+               "cookie=%"PRIu64", bufused=%p)\n",
+               uvwasi,
+               fd,
+               buf,
+               buf_len,
+               cookie,
+               bufused);
 
   if (uvwasi == NULL || buf == NULL || bufused == NULL)
     return UVWASI_EINVAL;
@@ -1404,7 +1414,10 @@ exit:
 uvwasi_errno_t uvwasi_fd_renumber(uvwasi_t* uvwasi,
                                   uvwasi_fd_t from,
                                   uvwasi_fd_t to) {
-  DEBUG("uvwasi_fd_renumber(uvwasi=%p, from=%d, to=%d)\n", uvwasi, from, to);
+  UVWASI_DEBUG("uvwasi_fd_renumber(uvwasi=%p, from=%d, to=%d)\n",
+               uvwasi,
+               from,
+               to);
 
   if (uvwasi == NULL)
     return UVWASI_EINVAL;
@@ -1421,13 +1434,13 @@ uvwasi_errno_t uvwasi_fd_seek(uvwasi_t* uvwasi,
   struct uvwasi_fd_wrap_t* wrap;
   uvwasi_errno_t err;
 
-  DEBUG("uvwasi_fd_seek(uvwasi=%p, fd=%d, offset=%"PRId64", "
-        "whence=%d, newoffset=%p)\n",
-        uvwasi,
-        fd,
-        offset,
-        whence,
-        newoffset);
+  UVWASI_DEBUG("uvwasi_fd_seek(uvwasi=%p, fd=%d, offset=%"PRId64", "
+               "whence=%d, newoffset=%p)\n",
+               uvwasi,
+               fd,
+               offset,
+               whence,
+               newoffset);
 
   if (uvwasi == NULL || newoffset == NULL)
     return UVWASI_EINVAL;
@@ -1448,7 +1461,7 @@ uvwasi_errno_t uvwasi_fd_sync(uvwasi_t* uvwasi, uvwasi_fd_t fd) {
   uvwasi_errno_t err;
   int r;
 
-  DEBUG("uvwasi_fd_sync(uvwasi=%p, fd=%d)\n", uvwasi, fd);
+  UVWASI_DEBUG("uvwasi_fd_sync(uvwasi=%p, fd=%d)\n", uvwasi, fd);
 
   if (uvwasi == NULL)
     return UVWASI_EINVAL;
@@ -1478,7 +1491,10 @@ uvwasi_errno_t uvwasi_fd_tell(uvwasi_t* uvwasi,
   struct uvwasi_fd_wrap_t* wrap;
   uvwasi_errno_t err;
 
-  DEBUG("uvwasi_fd_tell(uvwasi=%p, fd=%d, offset=%p)\n", uvwasi, fd, offset);
+  UVWASI_DEBUG("uvwasi_fd_tell(uvwasi=%p, fd=%d, offset=%p)\n",
+               uvwasi,
+               fd,
+               offset);
 
   if (uvwasi == NULL || offset == NULL)
     return UVWASI_EINVAL;
@@ -1505,13 +1521,13 @@ uvwasi_errno_t uvwasi_fd_write(uvwasi_t* uvwasi,
   size_t uvwritten;
   int r;
 
-  DEBUG("uvwasi_fd_write(uvwasi=%p, fd=%d, iovs=%p, iovs_len=%d, "
-        "nwritten=%p)\n",
-        uvwasi,
-        fd,
-        iovs,
-        iovs_len,
-        nwritten);
+  UVWASI_DEBUG("uvwasi_fd_write(uvwasi=%p, fd=%d, iovs=%p, iovs_len=%d, "
+               "nwritten=%p)\n",
+               uvwasi,
+               fd,
+               iovs,
+               iovs_len,
+               nwritten);
 
   if (uvwasi == NULL || iovs == NULL || nwritten == NULL)
     return UVWASI_EINVAL;
@@ -1550,12 +1566,12 @@ uvwasi_errno_t uvwasi_path_create_directory(uvwasi_t* uvwasi,
   uvwasi_errno_t err;
   int r;
 
-  DEBUG("uvwasi_path_create_directory(uvwasi=%p, fd=%d, path='%s', "
-        "path_len=%d)\n",
-        uvwasi,
-        fd,
-        path,
-        path_len);
+  UVWASI_DEBUG("uvwasi_path_create_directory(uvwasi=%p, fd=%d, path='%s', "
+               "path_len=%d)\n",
+               uvwasi,
+               fd,
+               path,
+               path_len);
 
   if (uvwasi == NULL || path == NULL)
     return UVWASI_EINVAL;
@@ -1600,14 +1616,14 @@ uvwasi_errno_t uvwasi_path_filestat_get(uvwasi_t* uvwasi,
   uvwasi_errno_t err;
   int r;
 
-  DEBUG("uvwasi_path_filestat_get(uvwasi=%p, fd=%d, flags=%d, path='%s', "
-        "path_len=%d, buf=%p)\n",
-        uvwasi,
-        fd,
-        flags,
-        path,
-        path_len,
-        buf);
+  UVWASI_DEBUG("uvwasi_path_filestat_get(uvwasi=%p, fd=%d, flags=%d, "
+               "path='%s', path_len=%d, buf=%p)\n",
+               uvwasi,
+               fd,
+               flags,
+               path,
+               path_len,
+               buf);
 
   if (uvwasi == NULL || path == NULL || buf == NULL)
     return UVWASI_EINVAL;
@@ -1662,16 +1678,17 @@ uvwasi_errno_t uvwasi_path_filestat_set_times(uvwasi_t* uvwasi,
   uvwasi_errno_t err;
   int r;
 
-  DEBUG("uvwasi_path_filestat_set_times(uvwasi=%p, fd=%d, flags=%d, path='%s', "
-        "path_len=%d, st_atim=%"PRIu64", st_mtim=%"PRIu64", fst_flags=%d)\n",
-        uvwasi,
-        fd,
-        flags,
-        path,
-        path_len,
-        st_atim,
-        st_mtim,
-        fst_flags);
+  UVWASI_DEBUG("uvwasi_path_filestat_set_times(uvwasi=%p, fd=%d, "
+               "flags=%d, path='%s', path_len=%d, "
+               "st_atim=%"PRIu64", st_mtim=%"PRIu64", fst_flags=%d)\n",
+               uvwasi,
+               fd,
+               flags,
+               path,
+               path_len,
+               st_atim,
+               st_mtim,
+               fst_flags);
 
   if (uvwasi == NULL || path == NULL)
     return UVWASI_EINVAL;
@@ -1740,16 +1757,17 @@ uvwasi_errno_t uvwasi_path_link(uvwasi_t* uvwasi,
   uv_fs_t req;
   int r;
 
-  DEBUG("uvwasi_path_link(uvwasi=%p, old_fd=%d, old_flags=%d, old_path='%s', "
-        "old_path_len=%d, new_fd=%d, new_path='%s', new_path_len=%d)\n",
-        uvwasi,
-        old_fd,
-        old_flags,
-        old_path,
-        old_path_len,
-        new_fd,
-        new_path,
-        new_path_len);
+  UVWASI_DEBUG("uvwasi_path_link(uvwasi=%p, old_fd=%d, old_flags=%d, "
+               "old_path='%s', old_path_len=%d, new_fd=%d, new_path='%s', "
+               "new_path_len=%d)\n",
+               uvwasi,
+               old_fd,
+               old_flags,
+               old_path,
+               old_path_len,
+               new_fd,
+               new_path,
+               new_path_len);
 
   if (uvwasi == NULL || old_path == NULL || new_path == NULL)
     return UVWASI_EINVAL;
@@ -1854,19 +1872,19 @@ uvwasi_errno_t uvwasi_path_open(uvwasi_t* uvwasi,
   int write;
   int r;
 
-  DEBUG("uvwasi_path_open(uvwasi=%p, dirfd=%d, dirflags=%d, path='%s', "
-        "path_len=%d, o_flags=%d, fs_rights_base=%"PRIu64", "
-        "fs_rights_inheriting=%"PRIu64", fs_flags=%d, fd=%p)\n",
-        uvwasi,
-        dirfd,
-        dirflags,
-        path,
-        path_len,
-        o_flags,
-        fs_rights_base,
-        fs_rights_inheriting,
-        fs_flags,
-        fd);
+  UVWASI_DEBUG("uvwasi_path_open(uvwasi=%p, dirfd=%d, dirflags=%d, path='%s', "
+               "path_len=%d, o_flags=%d, fs_rights_base=%"PRIu64", "
+               "fs_rights_inheriting=%"PRIu64", fs_flags=%d, fd=%p)\n",
+               uvwasi,
+               dirfd,
+               dirflags,
+               path,
+               path_len,
+               o_flags,
+               fs_rights_base,
+               fs_rights_inheriting,
+               fs_flags,
+               fd);
 
   if (uvwasi == NULL || path == NULL || fd == NULL)
     return UVWASI_EINVAL;
@@ -2001,15 +2019,15 @@ uvwasi_errno_t uvwasi_path_readlink(uvwasi_t* uvwasi,
   size_t len;
   int r;
 
-  DEBUG("uvwasi_path_readlink(uvwasi=%p, fd=%d, path='%s', path_len=%d, "
-        "buf=%p, buf_len=%d, bufused=%p)\n",
-        uvwasi,
-        fd,
-        path,
-        path_len,
-        buf,
-        buf_len,
-        bufused);
+  UVWASI_DEBUG("uvwasi_path_readlink(uvwasi=%p, fd=%d, path='%s', path_len=%d, "
+               "buf=%p, buf_len=%d, bufused=%p)\n",
+               uvwasi,
+               fd,
+               path,
+               path_len,
+               buf,
+               buf_len,
+               bufused);
 
   if (uvwasi == NULL || path == NULL || buf == NULL || bufused == NULL)
     return UVWASI_EINVAL;
@@ -2060,12 +2078,12 @@ uvwasi_errno_t uvwasi_path_remove_directory(uvwasi_t* uvwasi,
   uvwasi_errno_t err;
   int r;
 
-  DEBUG("uvwasi_path_remove_directory(uvwasi=%p, fd=%d, path='%s', "
-        "path_len=%d)\n",
-        uvwasi,
-        fd,
-        path,
-        path_len);
+  UVWASI_DEBUG("uvwasi_path_remove_directory(uvwasi=%p, fd=%d, path='%s', "
+               "path_len=%d)\n",
+               uvwasi,
+               fd,
+               path,
+               path_len);
 
   if (uvwasi == NULL || path == NULL)
     return UVWASI_EINVAL;
@@ -2111,15 +2129,15 @@ uvwasi_errno_t uvwasi_path_rename(uvwasi_t* uvwasi,
   uv_fs_t req;
   int r;
 
-  DEBUG("uvwasi_path_rename(uvwasi=%p, old_fd=%d, old_path='%s', "
-        "old_path_len=%d, new_fd=%d, new_path='%s', new_path_len=%d)\n",
-        uvwasi,
-        old_fd,
-        old_path,
-        old_path_len,
-        new_fd,
-        new_path,
-        new_path_len);
+  UVWASI_DEBUG("uvwasi_path_rename(uvwasi=%p, old_fd=%d, old_path='%s', "
+               "old_path_len=%d, new_fd=%d, new_path='%s', new_path_len=%d)\n",
+               uvwasi,
+               old_fd,
+               old_path,
+               old_path_len,
+               new_fd,
+               new_path,
+               new_path_len);
 
   if (uvwasi == NULL || old_path == NULL || new_path == NULL)
     return UVWASI_EINVAL;
@@ -2211,14 +2229,14 @@ uvwasi_errno_t uvwasi_path_symlink(uvwasi_t* uvwasi,
   uv_fs_t req;
   int r;
 
-  DEBUG("uvwasi_path_symlink(uvwasi=%p, old_path='%s', old_path_len=%d, "
-        "fd=%d, new_path='%s', new_path_len=%d)\n",
-        uvwasi,
-        old_path,
-        old_path_len,
-        fd,
-        new_path,
-        new_path_len);
+  UVWASI_DEBUG("uvwasi_path_symlink(uvwasi=%p, old_path='%s', old_path_len=%d, "
+               "fd=%d, new_path='%s', new_path_len=%d)\n",
+               uvwasi,
+               old_path,
+               old_path_len,
+               fd,
+               new_path,
+               new_path_len);
 
   if (uvwasi == NULL || old_path == NULL || new_path == NULL)
     return UVWASI_EINVAL;
@@ -2264,11 +2282,12 @@ uvwasi_errno_t uvwasi_path_unlink_file(uvwasi_t* uvwasi,
   uvwasi_errno_t err;
   int r;
 
-  DEBUG("uvwasi_path_unlink_file(uvwasi=%p, fd=%d, path='%s', path_len=%d)\n",
-        uvwasi,
-        fd,
-        path,
-        path_len);
+  UVWASI_DEBUG("uvwasi_path_unlink_file(uvwasi=%p, fd=%d, path='%s', "
+               "path_len=%d)\n",
+               uvwasi,
+               fd,
+               path,
+               path_len);
 
   if (uvwasi == NULL || path == NULL)
     return UVWASI_EINVAL;
@@ -2316,13 +2335,13 @@ uvwasi_errno_t uvwasi_poll_oneoff(uvwasi_t* uvwasi,
   int has_timeout;
   uvwasi_size_t i;
 
-  DEBUG("uvwasi_poll_oneoff(uvwasi=%p, in=%p, out=%p, nsubscriptions=%d, "
-        "nevents=%p)\n",
-        uvwasi,
-        in,
-        out,
-        nsubscriptions,
-        nevents);
+  UVWASI_DEBUG("uvwasi_poll_oneoff(uvwasi=%p, in=%p, out=%p, "
+               "nsubscriptions=%d, nevents=%p)\n",
+               uvwasi,
+               in,
+               out,
+               nsubscriptions,
+               nevents);
 
   if (uvwasi == NULL || in == NULL || out == NULL ||
       nsubscriptions == 0 || nevents == NULL) {
@@ -2422,7 +2441,7 @@ exit:
 
 
 uvwasi_errno_t uvwasi_proc_exit(uvwasi_t* uvwasi, uvwasi_exitcode_t rval) {
-  DEBUG("uvwasi_proc_exit(uvwasi=%p, rval=%d)\n", uvwasi, rval);
+  UVWASI_DEBUG("uvwasi_proc_exit(uvwasi=%p, rval=%d)\n", uvwasi, rval);
   exit(rval);
   return UVWASI_ESUCCESS; /* This doesn't happen. */
 }
@@ -2431,7 +2450,7 @@ uvwasi_errno_t uvwasi_proc_exit(uvwasi_t* uvwasi, uvwasi_exitcode_t rval) {
 uvwasi_errno_t uvwasi_proc_raise(uvwasi_t* uvwasi, uvwasi_signal_t sig) {
   int r;
 
-  DEBUG("uvwasi_proc_raise(uvwasi=%p, sig=%d)\n", uvwasi, sig);
+  UVWASI_DEBUG("uvwasi_proc_raise(uvwasi=%p, sig=%d)\n", uvwasi, sig);
 
   if (uvwasi == NULL)
     return UVWASI_EINVAL;
@@ -2453,10 +2472,10 @@ uvwasi_errno_t uvwasi_random_get(uvwasi_t* uvwasi,
                                  uvwasi_size_t buf_len) {
   int r;
 
-  DEBUG("uvwasi_random_get(uvwasi=%p, buf=%p, buf_len=%d)\n",
-        uvwasi,
-        buf,
-        buf_len);
+  UVWASI_DEBUG("uvwasi_random_get(uvwasi=%p, buf=%p, buf_len=%d)\n",
+               uvwasi,
+               buf,
+               buf_len);
 
   if (uvwasi == NULL || buf == NULL)
     return UVWASI_EINVAL;
@@ -2470,7 +2489,7 @@ uvwasi_errno_t uvwasi_random_get(uvwasi_t* uvwasi,
 
 
 uvwasi_errno_t uvwasi_sched_yield(uvwasi_t* uvwasi) {
-  DEBUG("uvwasi_sched_yield(uvwasi=%p)\n", uvwasi);
+  UVWASI_DEBUG("uvwasi_sched_yield(uvwasi=%p)\n", uvwasi);
 
   if (uvwasi == NULL)
     return UVWASI_EINVAL;
@@ -2495,7 +2514,7 @@ uvwasi_errno_t uvwasi_sock_recv(uvwasi_t* uvwasi,
                                 uvwasi_roflags_t* ro_flags) {
   /* TODO(cjihrig): Waiting to implement, pending
                     https://github.com/WebAssembly/WASI/issues/4 */
-  DEBUG("uvwasi_sock_recv(uvwasi=%p, unimplemented)\n", uvwasi);
+  UVWASI_DEBUG("uvwasi_sock_recv(uvwasi=%p, unimplemented)\n", uvwasi);
   return UVWASI_ENOTSUP;
 }
 
@@ -2508,7 +2527,7 @@ uvwasi_errno_t uvwasi_sock_send(uvwasi_t* uvwasi,
                                 uvwasi_size_t* so_datalen) {
   /* TODO(cjihrig): Waiting to implement, pending
                     https://github.com/WebAssembly/WASI/issues/4 */
-  DEBUG("uvwasi_sock_send(uvwasi=%p, unimplemented)\n", uvwasi);
+  UVWASI_DEBUG("uvwasi_sock_send(uvwasi=%p, unimplemented)\n", uvwasi);
   return UVWASI_ENOTSUP;
 }
 
@@ -2518,7 +2537,7 @@ uvwasi_errno_t uvwasi_sock_shutdown(uvwasi_t* uvwasi,
                                     uvwasi_sdflags_t how) {
   /* TODO(cjihrig): Waiting to implement, pending
                     https://github.com/WebAssembly/WASI/issues/4 */
-  DEBUG("uvwasi_sock_shutdown(uvwasi=%p, unimplemented)\n", uvwasi);
+  UVWASI_DEBUG("uvwasi_sock_shutdown(uvwasi=%p, unimplemented)\n", uvwasi);
   return UVWASI_ENOTSUP;
 }
 


### PR DESCRIPTION
This commit renames the DEBUG() macro to prevent name collisions.

Fixes: https://github.com/cjihrig/uvwasi/issues/142