### PR TITLE
serdes: fix compilation errors on NetBSD 8.2

### DIFF
--- a/include/wasi_serdes.h
+++ b/include/wasi_serdes.h
@@ -9,17 +9,16 @@
   void uvwasi_serdes_write_##name(void* ptr, size_t offset, type value);      \
   type uvwasi_serdes_read_##name(const void* ptr, size_t offset);             \
 
-#define BASIC_TYPE(type) BASIC_TYPE_(type, type)
 #define BASIC_TYPE_UVWASI(type) BASIC_TYPE_(type, uvwasi_##type)
 
 #define UVWASI_SERDES_SIZE_uint8_t sizeof(uint8_t)
-BASIC_TYPE(uint8_t)
+BASIC_TYPE_(uint8_t, uint8_t)
 #define UVWASI_SERDES_SIZE_uint16_t sizeof(uint16_t)
-BASIC_TYPE(uint16_t)
+BASIC_TYPE_(uint16_t, uint16_t)
 #define UVWASI_SERDES_SIZE_uint32_t sizeof(uint32_t)
-BASIC_TYPE(uint32_t)
+BASIC_TYPE_(uint32_t, uint32_t)
 #define UVWASI_SERDES_SIZE_uint64_t sizeof(uint64_t)
-BASIC_TYPE(uint64_t)
+BASIC_TYPE_(uint64_t, uint64_t)
 
 #define UVWASI_SERDES_SIZE_advice_t sizeof(uvwasi_advice_t)
 BASIC_TYPE_UVWASI(advice_t)

--- a/include/wasi_serdes.h
+++ b/include/wasi_serdes.h
@@ -5,20 +5,20 @@
 
 /* Basic uint{8,16,32,64}_t read/write functions. */
 
-#define BASIC_TYPE_(name, type)                                               \
+#define BASIC_TYPE(name, type)                                                \
   void uvwasi_serdes_write_##name(void* ptr, size_t offset, type value);      \
   type uvwasi_serdes_read_##name(const void* ptr, size_t offset);             \
 
-#define BASIC_TYPE_UVWASI(type) BASIC_TYPE_(type, uvwasi_##type)
+#define BASIC_TYPE_UVWASI(type) BASIC_TYPE(type, uvwasi_##type)
 
 #define UVWASI_SERDES_SIZE_uint8_t sizeof(uint8_t)
-BASIC_TYPE_(uint8_t, uint8_t)
+BASIC_TYPE(uint8_t, uint8_t)
 #define UVWASI_SERDES_SIZE_uint16_t sizeof(uint16_t)
-BASIC_TYPE_(uint16_t, uint16_t)
+BASIC_TYPE(uint16_t, uint16_t)
 #define UVWASI_SERDES_SIZE_uint32_t sizeof(uint32_t)
-BASIC_TYPE_(uint32_t, uint32_t)
+BASIC_TYPE(uint32_t, uint32_t)
 #define UVWASI_SERDES_SIZE_uint64_t sizeof(uint64_t)
-BASIC_TYPE_(uint64_t, uint64_t)
+BASIC_TYPE(uint64_t, uint64_t)
 
 #define UVWASI_SERDES_SIZE_advice_t sizeof(uvwasi_advice_t)
 BASIC_TYPE_UVWASI(advice_t)
@@ -79,7 +79,6 @@ BASIC_TYPE_UVWASI(whence_t)
 
 #undef BASIC_TYPE_UVWASI
 #undef BASIC_TYPE
-#undef BASIC_TYPE_
 
 /* WASI structure read/write functions. */
 


### PR DESCRIPTION
This commit removes a macro, and fixes compilation errors on certain platforms such as NetBSD 8.2.

Refs: https://github.com/nodejs/node/issues/34510
Fixes: https://github.com/cjihrig/uvwasi/issues/145