### PR TITLE
v0.0.10

### DIFF
--- a/include/uvwasi.h
+++ b/include/uvwasi.h
@@ -10,7 +10,7 @@ extern "C" {
 
 #define UVWASI_VERSION_MAJOR 0
 #define UVWASI_VERSION_MINOR 0
-#define UVWASI_VERSION_PATCH 9
+#define UVWASI_VERSION_PATCH 10
 #define UVWASI_VERSION_HEX ((UVWASI_VERSION_MAJOR << 16) | \
                             (UVWASI_VERSION_MINOR <<  8) | \
                             (UVWASI_VERSION_PATCH))


### PR DESCRIPTION
Notable changes:

- The `uvwasi_preopen_t` now uses `const char*` for the `mapped_path` and `real_path` fields. Previously, these were not `const`. (https://github.com/cjihrig/uvwasi/pull/130)
- `uvwasi_path_filestat_get()` now properly handles the `UVWASI_LOOKUP_SYMLINK_FOLLOW` flag. (https://github.com/cjihrig/uvwasi/pull/133)
- `uvwasi_options_init()` has been added to reduce the boilerplate code associated with initializing `uvwasi_options_t`'s. (https://github.com/cjihrig/uvwasi/pull/141)
- The `DEBUG()` macro has been renamed to `UVWASI_DEBUG()` to reduce naming conflicts with other projects. (https://github.com/cjihrig/uvwasi/pull/143)
- A compilation error on NetBSD 8.2 has been fixed. (https://github.com/cjihrig/uvwasi/pull/146)
- The `uvwasi_fd_filestat_set_times()` and `uvwasi_path_filestat_set_times()` functions now have proper implementations. (https://github.com/cjihrig/uvwasi/pull/139)