### PR TITLE
src: suppress maybe-uninitialized timer_userdata

### DIFF
--- a/src/uvwasi.c
+++ b/src/uvwasi.c
@@ -2325,7 +2325,7 @@ uvwasi_errno_t uvwasi_poll_oneoff(uvwasi_t* uvwasi,
                                   uvwasi_size_t* nevents) {
   struct uvwasi_poll_oneoff_state_t state;
   struct uvwasi__poll_fdevent_t* fdevent;
-  uvwasi_userdata_t timer_userdata = 0;
+  uvwasi_userdata_t timer_userdata;
   uvwasi_timestamp_t min_timeout;
   uvwasi_timestamp_t cur_timeout;
   uvwasi_timestamp_t now;
@@ -2334,6 +2334,7 @@ uvwasi_errno_t uvwasi_poll_oneoff(uvwasi_t* uvwasi,
   uvwasi_errno_t err;
   int has_timeout;
   uvwasi_size_t i;
+  timer_userdata = 0;
 
   UVWASI_DEBUG("uvwasi_poll_oneoff(uvwasi=%p, in=%p, out=%p, "
                "nsubscriptions=%d, nevents=%p)\n",

--- a/src/uvwasi.c
+++ b/src/uvwasi.c
@@ -2325,7 +2325,7 @@ uvwasi_errno_t uvwasi_poll_oneoff(uvwasi_t* uvwasi,
                                   uvwasi_size_t* nevents) {
   struct uvwasi_poll_oneoff_state_t state;
   struct uvwasi__poll_fdevent_t* fdevent;
-  uvwasi_userdata_t timer_userdata;
+  uvwasi_userdata_t timer_userdata = 0;
   uvwasi_timestamp_t min_timeout;
   uvwasi_timestamp_t cur_timeout;
   uvwasi_timestamp_t now;


### PR DESCRIPTION
This commit initializes timer_userdata to avoid a maybe-uninitialized
warning in uvwasi_poll_oneoff.

This warning can be seen when building using the following flags (and
also shows up in Node.js build):
```console
$ cd build
$ cmake .. -DCMAKE_C_FLAGS="-Wmaybe-uninitialized -O3"
$ make -j8
...
/wasm/uvwasi/src/uvwasi.c: In function ‘uvwasi_poll_oneoff’:
/wasm/uvwasi/src/uvwasi.c:2407:21: warning:
‘timer_userdata’ may be used uninitialized in this function [-Wmaybe-uninitialized]
 2407 |     event->userdata = timer_userdata;
      |     ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~
```