### PR TITLE
build: add uvwasi to build summary

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,7 +115,7 @@ if(UVWASI_BUILD_TESTS)
     )
 endif()
 
-message(STATUS "summary of build options:
+message(STATUS "summary of uvwasi build options:
 
     Install prefix:  ${CMAKE_INSTALL_PREFIX}
     Target system:   ${CMAKE_SYSTEM_NAME}


### PR DESCRIPTION
Currently, the summary when configuring the build with cmake look like
this:
```console
-- summary of build options:
    Install prefix:  /usr/local
    Target system:   Linux
    Compiler:
      C compiler:    /usr/lib64/ccache/cc
      CFLAGS:         -Wmaybe-uninitialized -O3

-- summary of build options:

    Install prefix:  /usr/local
    Target system:   Linux
    Compiler:
      C compiler:    /usr/lib64/ccache/cc
      CFLAGS:         -Wmaybe-uninitialized -O3
    Libuv version:   v1.38.1
    Libuv lib:       /wasm/uvwasi/build/_deps/libuv-build

-- Configuring done
-- Generating done
-- Build files have been written to: /wasm/uvwasi/build
```
The first summary is from libuv and the second is from this project.
This commit suggest adding uvwasi to the second to make it clear which
properties belong to which project(at first I though that the
configuration was somehow being run twice).