### PR TITLE
src: improve uvwasi_fd_readdir() implementation

### DIFF
--- a/include/wasi_serdes.h
+++ b/include/wasi_serdes.h
@@ -103,6 +103,9 @@ IOVS_STRUCT(ciovec_t)
 #define UVWASI_SERDES_SIZE_iovec_t 8
 IOVS_STRUCT(iovec_t)
 
+#define UVWASI_SERDES_SIZE_dirent_t 24
+STRUCT(dirent_t)
+
 #define UVWASI_SERDES_SIZE_fdstat_t 24
 STRUCT(fdstat_t)
 

--- a/src/uvwasi.c
+++ b/src/uvwasi.c
@@ -13,6 +13,10 @@
 
 #define UVWASI__READDIR_NUM_ENTRIES 1
 
+#if !defined(_WIN32) && !defined(__ANDROID__)
+# define UVWASI_FD_READDIR_SUPPORTED 1
+#endif
+
 #include "uvwasi.h"
 #include "uvwasi_alloc.h"
 #include "uv.h"
@@ -22,6 +26,7 @@
 #include "path_resolver.h"
 #include "poll_oneoff.h"
 #include "wasi_rights.h"
+#include "wasi_serdes.h"
 #include "debug.h"
 
 /* IBMi PASE does not support posix_fadvise() */
@@ -1268,7 +1273,7 @@ uvwasi_errno_t uvwasi_fd_readdir(uvwasi_t* uvwasi,
                                  uvwasi_size_t buf_len,
                                  uvwasi_dircookie_t cookie,
                                  uvwasi_size_t* bufused) {
-  /* TODO(cjihrig): Support Windows where seekdir() and telldir() are used. */
+#if defined(UVWASI_FD_READDIR_SUPPORTED)
   /* TODO(cjihrig): Avoid opening and closing the directory on each call. */
   struct uvwasi_fd_wrap_t* wrap;
   uvwasi_dirent_t dirent;
@@ -1282,6 +1287,7 @@ uvwasi_errno_t uvwasi_fd_readdir(uvwasi_t* uvwasi,
   long tell;
   int i;
   int r;
+#endif /* defined(UVWASI_FD_READDIR_SUPPORTED) */
 
   UVWASI_DEBUG("uvwasi_fd_readdir(uvwasi=%p, fd=%d, buf=%p, buf_len=%d, "
                "cookie=%"PRIu64", bufused=%p)\n",
@@ -1295,6 +1301,7 @@ uvwasi_errno_t uvwasi_fd_readdir(uvwasi_t* uvwasi,
   if (uvwasi == NULL || buf == NULL || bufused == NULL)
     return UVWASI_EINVAL;
 
+#if defined(UVWASI_FD_READDIR_SUPPORTED)
   err = uvwasi_fd_table_get(uvwasi->fds,
                             fd,
                             &wrap,
@@ -1316,12 +1323,9 @@ uvwasi_errno_t uvwasi_fd_readdir(uvwasi_t* uvwasi,
   dir->nentries = UVWASI__READDIR_NUM_ENTRIES;
   uv_fs_req_cleanup(&req);
 
-#ifndef _WIN32
-  /* TODO(cjihrig): Need a Windows equivalent of this logic. */
   /* Seek to the proper location in the directory. */
   if (cookie != UVWASI_DIRCOOKIE_START)
     seekdir(dir->dir, cookie);
-#endif
 
   /* Read the directory entries into the provided buffer. */
   err = UVWASI_ESUCCESS;
@@ -1333,21 +1337,15 @@ uvwasi_errno_t uvwasi_fd_readdir(uvwasi_t* uvwasi,
       goto exit;
     }
 
+    available = 0;
+
     for (i = 0; i < r; i++) {
-      /* TODO(cjihrig): This should probably be serialized to the buffer
-         consistently across platforms. In other words, d_next should always
-         be 8 bytes, d_ino should always be 8 bytes, d_namlen should always be
-         4 bytes, and d_type should always be 1 byte. */
-#ifndef _WIN32
       tell = telldir(dir->dir);
       if (tell < 0) {
         err = uvwasi__translate_uv_error(uv_translate_sys_error(errno));
         uv_fs_req_cleanup(&req);
         goto exit;
       }
-#else
-      tell = 0; /* TODO(cjihrig): Need to support Windows. */
-#endif /* _WIN32 */
 
       name_len = strlen(dirents[i].name);
       dirent.d_next = (uvwasi_dircookie_t) tell;
@@ -1381,21 +1379,24 @@ uvwasi_errno_t uvwasi_fd_readdir(uvwasi_t* uvwasi,
           break;
       }
 
-      /* Write dirent to the buffer. */
+      /* Write dirent to the buffer if it will fit. */
+      if (UVWASI_SERDES_SIZE_dirent_t + *bufused > buf_len)
+        break;
+
+      uvwasi_serdes_write_dirent_t(buf, *bufused, &dirent);
+      *bufused += UVWASI_SERDES_SIZE_dirent_t;
       available = buf_len - *bufused;
-      size_to_cp = sizeof(dirent) > available ? available : sizeof(dirent);
-      memcpy((char*)buf + *bufused, &dirent, size_to_cp);
-      *bufused += size_to_cp;
-      /* Write the entry name to the buffer. */
-      available = buf_len - *bufused;
+
+      /* Write as much of the entry name to the buffer as possible. */
       size_to_cp = name_len > available ? available : name_len;
-      memcpy((char*)buf + *bufused, &dirents[i].name, size_to_cp);
+      memcpy((char*)buf + *bufused, dirents[i].name, size_to_cp);
       *bufused += size_to_cp;
+      available = buf_len - *bufused;
     }
 
     uv_fs_req_cleanup(&req);
 
-    if (*bufused >= buf_len)
+    if (available == 0)
       break;
   }
 
@@ -1408,6 +1409,10 @@ exit:
     return uvwasi__translate_uv_error(r);
 
   return err;
+#else
+  /* TODO(cjihrig): Need a solution for Windows and Android. */
+  return UVWASI_ENOSYS;
+#endif /* defined(UVWASI_FD_READDIR_SUPPORTED) */
 }
 
 

--- a/src/wasi_serdes.c
+++ b/src/wasi_serdes.c
@@ -84,6 +84,13 @@ uint8_t uvwasi_serdes_read_uint8_t(const void* ptr,  size_t offset) {
   ALIAS(userdata_t,      uint64_t)                                            \
   ALIAS(whence_t,        uint8_t)                                             \
                                                                               \
+  STRUCT(dirent_t) {                                                          \
+    FIELD( 0, dircookie_t, d_next);                                           \
+    FIELD( 8, inode_t,     d_ino);                                            \
+    FIELD(16, uint32_t,    d_namlen);                                         \
+    FIELD(20, filetype_t,  d_type);                                           \
+  }                                                                           \
+                                                                              \
   STRUCT(fdstat_t) {                                                          \
     FIELD( 0, filetype_t, fs_filetype);                                       \
     FIELD( 2, fdflags_t,  fs_flags);                                          \

--- a/test/test-ebadf-input-validation.c
+++ b/test/test-ebadf-input-validation.c
@@ -43,7 +43,12 @@ int main(void) {
   CHECK(uvwasi_fd_prestat_dir_name(&uvw, 100, test_str, 10));
   CHECK(uvwasi_fd_pwrite(&uvw, 100, &test_ciovec, 2, 10, &test_size));
   CHECK(uvwasi_fd_read(&uvw, 100, &test_iovec, 2, &test_size));
+#if !defined(_WIN32) && !defined(__ANDROID__)
   CHECK(uvwasi_fd_readdir(&uvw, 100, test_void, 3, test_dircookie, &test_size));
+#else
+  assert(UVWASI_ENOSYS ==
+      uvwasi_fd_readdir(&uvw, 100, test_void, 3, test_dircookie, &test_size));
+#endif /* !defined(_WIN32) && !defined(__ANDROID__) */
   CHECK(uvwasi_fd_renumber(&uvw, 100, 2));
   CHECK(uvwasi_fd_seek(&uvw, 100, 10, UVWASI_WHENCE_CUR, &test_filesize));
   CHECK(uvwasi_fd_sync(&uvw, 100));

--- a/test/test-fd-readdir.c
+++ b/test/test-fd-readdir.c
@@ -1,0 +1,115 @@
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+#include "uv.h"
+#include "uvwasi.h"
+#include "wasi_serdes.h"
+
+#define TEST_TMP_DIR "./out/tmp"
+#define TEST_PATH_READDIR TEST_TMP_DIR "/test_readdir"
+#define TEST_PATH_FILE_1 TEST_PATH_READDIR "/test_file_1"
+#define TEST_PATH_FILE_2 TEST_PATH_READDIR "/test_file_2"
+
+
+#if !defined(_WIN32) && !defined(__ANDROID__)
+static void touch_file(const char* name) {
+  uv_fs_t req;
+  int r;
+
+  r = uv_fs_open(NULL,
+                 &req,
+                 name,
+                 O_WRONLY | O_CREAT | O_TRUNC,
+                 S_IWUSR | S_IRUSR,
+                 NULL);
+  uv_fs_req_cleanup(&req);
+  assert(r >= 0);
+  r = uv_fs_close(NULL, &req, r, NULL);
+  uv_fs_req_cleanup(&req);
+  assert(r == 0);
+}
+#endif /* !defined(_WIN32) && !defined(__ANDROID__) */
+
+
+int main(void) {
+#if !defined(_WIN32) && !defined(__ANDROID__)
+  uvwasi_t uvwasi;
+  uvwasi_options_t init_options;
+  uvwasi_dircookie_t cookie;
+  uvwasi_dirent_t dirent;
+  uvwasi_size_t buf_size;
+  uvwasi_size_t buf_used;
+  uvwasi_errno_t err;
+  uv_fs_t req;
+  char buf[1024];
+  char* name;
+  int r;
+
+  r = uv_fs_mkdir(NULL, &req, TEST_TMP_DIR, 0777, NULL);
+  uv_fs_req_cleanup(&req);
+  assert(r == 0 || r == UV_EEXIST);
+
+  r = uv_fs_mkdir(NULL, &req, TEST_PATH_READDIR, 0777, NULL);
+  uv_fs_req_cleanup(&req);
+  assert(r == 0 || r == UV_EEXIST);
+
+  touch_file(TEST_PATH_FILE_1);
+  touch_file(TEST_PATH_FILE_2);
+
+  uvwasi_options_init(&init_options);
+  init_options.preopenc = 1;
+  init_options.preopens = calloc(1, sizeof(uvwasi_preopen_t));
+  init_options.preopens[0].mapped_path = "/var";
+  init_options.preopens[0].real_path = TEST_PATH_READDIR;
+
+  err = uvwasi_init(&uvwasi, &init_options);
+  assert(err == 0);
+
+  buf_size = 1024;
+
+  /* Verify uvwasi_fd_readdir() behavior with insufficient buffer space. */
+  memset(buf, 0, buf_size);
+  buf_used = 0;
+  cookie = UVWASI_DIRCOOKIE_START;
+  err = uvwasi_fd_readdir(&uvwasi,
+                          3,
+                          &buf,
+                          UVWASI_SERDES_SIZE_dirent_t + 10,
+                          cookie,
+                          &buf_used);
+  assert(err == 0);
+  assert(buf_used == UVWASI_SERDES_SIZE_dirent_t + 10);
+  uvwasi_serdes_read_dirent_t(buf, 0, &dirent);
+  assert(dirent.d_ino == 0);
+  assert(dirent.d_namlen == 11);
+  assert(dirent.d_type == UVWASI_FILETYPE_REGULAR_FILE);
+  name = &buf[UVWASI_SERDES_SIZE_dirent_t];
+  assert(strcmp(name, "test_file_") == 0);
+
+  /* Verify uvwasi_fd_readdir() happy path. */
+  memset(buf, 0, buf_size);
+  buf_used = 0;
+  cookie = UVWASI_DIRCOOKIE_START;
+  err = uvwasi_fd_readdir(&uvwasi, 3, &buf, buf_size, cookie, &buf_used);
+  assert(err == 0);
+  assert(buf_used == 2 * (UVWASI_SERDES_SIZE_dirent_t + 11));
+  uvwasi_serdes_read_dirent_t(buf, 0, &dirent);
+  assert(dirent.d_ino == 0);
+  assert(dirent.d_namlen == 11);
+  assert(dirent.d_type == UVWASI_FILETYPE_REGULAR_FILE);
+  name = &buf[UVWASI_SERDES_SIZE_dirent_t];
+  assert(strncmp(name, "test_file_1", 11) == 0 ||
+         strncmp(name, "test_file_2", 11) == 0);
+  uvwasi_serdes_read_dirent_t(buf, UVWASI_SERDES_SIZE_dirent_t + 11, &dirent);
+  assert(dirent.d_ino == 0);
+  assert(dirent.d_namlen == 11);
+  assert(dirent.d_type == UVWASI_FILETYPE_REGULAR_FILE);
+  name = &buf[(2 * UVWASI_SERDES_SIZE_dirent_t) + 11];
+  assert(strncmp(name, "test_file_1", 11) == 0 ||
+         strncmp(name, "test_file_2", 11) == 0);
+
+  uvwasi_destroy(&uvwasi);
+  free(init_options.preopens);
+#endif /* !defined(_WIN32) && !defined(__ANDROID__) */
+  return 0;
+}


### PR DESCRIPTION
This commit updates the uvwasi_fd_readdir() implementation
to work, including a regression test. The function is not
supported on Windows and Android yet.

Fixes: https://github.com/cjihrig/uvwasi/issues/148
Fixes: https://github.com/cjihrig/uvwasi/issues/137