### PR TITLE
Update link to WASI snapshot 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2453,4 +2453,4 @@ Possible values:
 
 [WASI]: https://github.com/WebAssembly/WASI
 [libuv]: https://github.com/libuv/libuv
-[snapshot_1]: https://github.com/WebAssembly/WASI/blob/master/phases/snapshot/docs/wasi_unstable_preview1.md
+[snapshot_1]: https://github.com/WebAssembly/WASI/blob/master/phases/snapshot/docs.md


### PR DESCRIPTION
The current link to the snapshot returns a 404. A permalink to the old document is [here](https://github.com/WebAssembly/WASI/blob/17f33a538161bcf4476ea9eae53cdcf7dbd96c35/phases/snapshot/docs/wasi_unstable_preview1.md). I've updated the README to point to the new location of the WASI snapshot 1. Thanks!