### PR TITLE
Make options const for uvwasi_init

### DIFF
--- a/include/uvwasi.h
+++ b/include/uvwasi.h
@@ -68,7 +68,7 @@ typedef struct uvwasi_options_s {
 } uvwasi_options_t;
 
 /* Embedder API. */
-uvwasi_errno_t uvwasi_init(uvwasi_t* uvwasi, uvwasi_options_t* options);
+uvwasi_errno_t uvwasi_init(uvwasi_t* uvwasi, const uvwasi_options_t* options);
 void uvwasi_destroy(uvwasi_t* uvwasi);
 void uvwasi_options_init(uvwasi_options_t* options);
 /* Use int instead of uv_file to avoid needing uv.h */

--- a/src/fd_table.c
+++ b/src/fd_table.c
@@ -172,7 +172,7 @@ exit:
 
 
 uvwasi_errno_t uvwasi_fd_table_init(uvwasi_t* uvwasi,
-                                    uvwasi_options_t* options) {
+                                    const uvwasi_options_t* options) {
   struct uvwasi_fd_table_t* table;
   uvwasi_errno_t err;
   int r;

--- a/src/fd_table.h
+++ b/src/fd_table.h
@@ -29,7 +29,7 @@ struct uvwasi_fd_table_t {
 };
 
 uvwasi_errno_t uvwasi_fd_table_init(struct uvwasi_s* uvwasi,
-                                    struct uvwasi_options_s* options);
+                                    const struct uvwasi_options_s* options);
 void uvwasi_fd_table_free(struct uvwasi_s* uvwasi,
                           struct uvwasi_fd_table_t* table);
 uvwasi_errno_t uvwasi_fd_table_insert(struct uvwasi_s* uvwasi,

--- a/src/uvwasi.c
+++ b/src/uvwasi.c
@@ -229,7 +229,7 @@ static uvwasi_errno_t uvwasi__setup_ciovs(const uvwasi_t* uvwasi,
 }
 
 
-uvwasi_errno_t uvwasi_init(uvwasi_t* uvwasi, uvwasi_options_t* options) {
+uvwasi_errno_t uvwasi_init(uvwasi_t* uvwasi, const uvwasi_options_t* options) {
   uv_fs_t realpath_req;
   uv_fs_t open_req;
   uvwasi_errno_t err;


### PR DESCRIPTION
It is a minor change, but this simplifies calling `uwasi_init`.

I have not seen a real reason why this would need to be non-const as nothing is modified.